### PR TITLE
Corrigido lançamento de notas por turma, para listar matriculas aprovadas e reprovadas.

### DIFF
--- a/ieducar/modules/Avaliacao/Views/DiarioApiController.php
+++ b/ieducar/modules/Avaliacao/Views/DiarioApiController.php
@@ -552,7 +552,7 @@ class DiarioApiController extends ApiCoreController
         $this->getRequest()->instituicao_id,
         $this->getRequest()->aluno_id,
         NULL,
-        3,
+        array(1, 2, 3),
         NULL,
         NULL,
         $this->getRequest()->ano,


### PR DESCRIPTION
Corrigido erro inserido pela issue #25, que passou a listar somente matriculas em andamento, conforme comentário [1] realizado no referido commit:

[1] https://github.com/portabilis/ieducar/commit/8add19a01e8c49c34b9453aceabd342f8ae445b7#commitcomment-4785615
