### PR TITLE
Corrigido erro no cadastro de turmas.

### DIFF
--- a/ieducar/intranet/educar_turma_cad.php
+++ b/ieducar/intranet/educar_turma_cad.php
@@ -1289,15 +1289,6 @@ document.getElementById('ref_cod_escola').onchange = function()
   if (document.getElementById('ref_cod_escola').value == '') {
     getCurso();
   }
-
-  $('img_colecao').style.display = 'none;';
-
-  if ($F('ref_cod_instituicao') == '') {
-    $('img_turma').style.display = 'none;';
-  }
-  else {
-    $('img_turma').style.display = '';
-  }
 }
 
 document.getElementById('ref_cod_curso').onchange = function()
@@ -1310,13 +1301,6 @@ document.getElementById('ref_cod_curso').onchange = function()
   getEscolaCursoSerie();
 
   PadraoAnoEscolar_xml();
-
-  if (this.value == '') {
-    $('img_colecao').style.display = 'none;';
-  }
-  else {
-    $('img_colecao').style.display = '';
-  }
 }
 
 function PadraoAnoEscolar_xml()


### PR DESCRIPTION
Olá @lucassch !

No seu commit 34a3c67e0b328e5219e4afd8d67a7259e04c7e0e foi removido os elementos html dos botões de cadastro rápido como o de série do cadastro de turma.

Porem você não removeu o código Javascript que dependia destes elementos, o que ocasionou um erro impeditivo no referido cadastro, impossibilitando a seleção de escolas.

Este erro afeta todos os usuários do i-Educar que atualizaram suas instalações recentemente.

Este pull request corrige este erro, removendo o código javascript agora desnecessário.