### PR TITLE
Trata erros ao carregar disciplinas da série na API de disciplinas.

### DIFF
--- a/ieducar/intranet/educar_disciplina_xml.php
+++ b/ieducar/intranet/educar_disciplina_xml.php
@@ -57,8 +57,13 @@ if (is_numeric($_GET['cur']) || is_numeric($_GET['ser'])) {
 if (is_numeric($_GET['esc']) && is_numeric($_GET['ser'])) {
   require_once 'App/Model/IedFinder.php';
 
-  $componentes = App_Model_IedFinder::getEscolaSerieDisciplina($_GET['ser'],
-    $_GET['esc']);
+  try {
+    $componentes = App_Model_IedFinder::getEscolaSerieDisciplina($_GET['ser'], $_GET['esc']);
+  } catch (Exception $e) {
+    echo '<disciplina>Erro: ' . $e->getMessage() . '</disciplina>';
+    echo "</query>";
+    die();
+  }
 }
 
 foreach ($componentes as $componente) {


### PR DESCRIPTION
Recentemente foi relatado na lista da comunidade, que ao tentar cadastrar uma turma era exibido 'Erro 500' após selecionar a série.

Isto ocorre pois a API de componentes curriculares não trata erros ao carregar os dados.

Pore é disparado uma excessão "Nenhuma disciplina para a série (X) e a escola (Y) informados" quando não existe componentes vinculados a série, o que interrompe a renderização do XML com um erro 500 no servidor.

Este commit altera a API de disciplinas para retornar uma mensagem de erro amigável para o usuário nos casos de erro ao buscar os dados.