### PR TITLE
[2.6] Torna configurável o boletim do professor

### DIFF
--- a/ieducar/modules/Api/Views/ReportController.php
+++ b/ieducar/modules/Api/Views/ReportController.php
@@ -121,6 +121,9 @@ class ReportController extends ApiCoreController
             $configuracoes = new clsPmieducarConfiguracoesGerais();
             $configuracoes = $configuracoes->detalhe();
 
+            $modelo = $configuracoes['modelo_boletim_professor'];
+
+            #$boletimProfessorReport->addArg('modelo', $modelo);
             $boletimProfessorReport->addArg('linha', 0);
             $boletimProfessorReport->addArg('SUBREPORT_DIR', config('legacy.report.source_path'));
 

--- a/ieducar/modules/Api/Views/ReportController.php
+++ b/ieducar/modules/Api/Views/ReportController.php
@@ -1,5 +1,7 @@
 <?php
 
+use iEducar\Reports\Contracts\TeacherReportCard;
+
 require_once 'Reports/Reports/ReportCardReport.php';
 require_once 'Reports/Reports/TeacherReportCardReport.php';
 
@@ -105,7 +107,7 @@ class ReportController extends ApiCoreController
     protected function getBoletimProfessor()
     {
         if ($this->canGetBoletimProfessor()) {
-            $boletimProfessorReport = new TeacherReportCardReport();
+            $boletimProfessorReport = app(TeacherReportCard::class);
 
             $boletimProfessorReport->addArg('ano', (int)$this->getRequest()->ano);
             $boletimProfessorReport->addArg('instituicao', (int)$this->getRequest()->instituicao_id);
@@ -123,7 +125,7 @@ class ReportController extends ApiCoreController
 
             $modelo = $configuracoes['modelo_boletim_professor'];
 
-            #$boletimProfessorReport->addArg('modelo', $modelo);
+            $boletimProfessorReport->addArg('modelo', $modelo);
             $boletimProfessorReport->addArg('linha', 0);
             $boletimProfessorReport->addArg('SUBREPORT_DIR', config('legacy.report.source_path'));
 

--- a/src/Reports/Contracts/TeacherReportCard.php
+++ b/src/Reports/Contracts/TeacherReportCard.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace iEducar\Reports\Contracts;
+
+interface TeacherReportCard
+{
+
+}


### PR DESCRIPTION
No PR https://github.com/portabilis/i-educar/pull/772 foi alterado a classe do relatório que gera o boletim, porém não é compatível com o uso interno.

Altera a forma de instanciação para utilizar uma classe definida no pacote específico dos relatórios.