### PR TITLE
[2.6] Adiciona configuração para ativar a exportação do arquivo do Educacenso

### DIFF
--- a/database/migrations/2020_08_03_000000_populate_settings_table.php
+++ b/database/migrations/2020_08_03_000000_populate_settings_table.php
@@ -109,6 +109,7 @@ class PopulateSettingsTable extends Migration
             'legacy.report.remote_factory.username' => null,
             'legacy.report.remote_factory.password' => null,
             'legacy.report.remote_factory.logo_name' => null,
+            'legacy.educacenso.enable_export' => 1,
         ];
 
         collect($settings)->each(function ($value, $key) {


### PR DESCRIPTION
DESCRIÇÃO:

Foi corrigido a ausência do parâmetro de exportação do arquivo para o censo escolar

AMBIENTE:

Plataforma utilizada (Docker, instalação direta)
Sistema operacional e versão (Ubuntu 16.04)
Navegador e versão (Chrome 91)