### PR TITLE
[2.6] Estrutura do banco de dados para a busca ativa

### DIFF
--- a/database/migrations/2021_05_27_101031_create_pmieducar_busca_ativa_table.php
+++ b/database/migrations/2021_05_27_101031_create_pmieducar_busca_ativa_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePmieducarBuscaAtivaTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('pmieducar.busca_ativa', function (Blueprint $table) {
+            $table->id();
+            $table->integer('ref_cod_matricula');
+            $table->date('data_inicio');
+            $table->date('data_fim')->nullable();
+            $table->smallInteger('resultado_busca_ativa')->default(2);
+            $table->text('observacoes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('ref_cod_matricula')
+                ->references('cod_matricula')
+                ->on('pmieducar.matricula');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('pmieducar.busca_ativa');
+    }
+}

--- a/database/migrations/2021_05_31_092518_create_active_looking_menu.php
+++ b/database/migrations/2021_05_31_092518_create_active_looking_menu.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Menu;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateActiveLookingMenu extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        $parent_id = Menu::query()->where('old', 55)->firstOrFail()->id;
+
+        Menu::query()->create([
+            'title' => 'Busca ativa',
+            'parent_id' => $parent_id,
+            'process' => 9998921,
+        ]);
+    }
+
+    public function down()
+    {
+        Menu::query()
+            ->where('process', 9998921)
+            ->delete();
+    }
+}


### PR DESCRIPTION
Adiciona migrações para criar a estrutura do banco de dados para o cadastro de Busca Ativa no sistema que foi adicionado na versão [2.6.2](https://github.com/portabilis/i-educar/releases/tag/2.6.2).

Refs https://github.com/portabilis/i-educar/pull/779.