### PR TITLE
[2.6] Portabilis patch 27/08/2021

### DIFF
--- a/app/Services/CopyAbsenceService.php
+++ b/app/Services/CopyAbsenceService.php
@@ -128,7 +128,7 @@ class CopyAbsenceService implements CopyRegistrationData
         LegacyStudentAbsence $studentAbsence,
         LegacyRegistration $oldRegistration
     ) {
-        $absences = $oldRegistration->studentAbsence->absences;
+        $absences = $oldRegistration->studentAbsence->absencesByDiscipline;
 
         foreach ($absences as $absence) {
             LegacyDisciplineAbsence::create(
@@ -152,7 +152,7 @@ class CopyAbsenceService implements CopyRegistrationData
         LegacyStudentAbsence $studentAbsence,
         LegacyRegistration $oldRegistration
     ) {
-        $absences = $oldRegistration->studentAbsence->absences;
+        $absences = $oldRegistration->studentAbsence->generalAbsences;
 
         foreach ($absences as $absence) {
             LegacyGeneralAbsence::create(

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Software livre de gestão escolar",
     "type": "project",
     "license": "GPL-2.0-or-later",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "keywords": [
         "Portabilis",
         "i-Educar"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be8e34db3a8377262418e86393780ceb",
+    "content-hash": "df498bf46c39b7c8a4aed122c56b7ff9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -64,16 +64,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.191.0",
+            "version": "3.191.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "15e97fe060decf30fa103be091b113adcc578c5d"
+                "reference": "3b01e0c7c1d9858e5d2f0ee9aa216d621f731765"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/15e97fe060decf30fa103be091b113adcc578c5d",
-                "reference": "15e97fe060decf30fa103be091b113adcc578c5d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3b01e0c7c1d9858e5d2f0ee9aa216d621f731765",
+                "reference": "3b01e0c7c1d9858e5d2f0ee9aa216d621f731765",
                 "shasum": ""
             },
             "require": {
@@ -148,9 +148,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.191.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.191.6"
             },
-            "time": "2021-08-19T18:15:49+00:00"
+            "time": "2021-08-27T18:14:01+00:00"
         },
         {
             "name": "aws/aws-sdk-php-laravel",
@@ -1951,16 +1951,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v8.55.0",
+            "version": "v8.57.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "997e2aa23e9103137715018ae926c52f8a1703f2"
+                "reference": "6de01746680d7bc7e239b20ec5cdfe70ce586235"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/997e2aa23e9103137715018ae926c52f8a1703f2",
-                "reference": "997e2aa23e9103137715018ae926c52f8a1703f2",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/6de01746680d7bc7e239b20ec5cdfe70ce586235",
+                "reference": "6de01746680d7bc7e239b20ec5cdfe70ce586235",
                 "shasum": ""
             },
             "require": {
@@ -2115,7 +2115,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-08-17T14:13:34+00:00"
+            "time": "2021-08-27T13:34:11+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -8414,16 +8414,16 @@
         },
         {
             "name": "facade/ignition",
-            "version": "2.11.4",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facade/ignition.git",
-                "reference": "1b8d83c5dac7c5ee8429daf284ce3f19b1d17ea2"
+                "reference": "74dcc32a2895a126d1e5f2cd3bbab499cac66db1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facade/ignition/zipball/1b8d83c5dac7c5ee8429daf284ce3f19b1d17ea2",
-                "reference": "1b8d83c5dac7c5ee8429daf284ce3f19b1d17ea2",
+                "url": "https://api.github.com/repos/facade/ignition/zipball/74dcc32a2895a126d1e5f2cd3bbab499cac66db1",
+                "reference": "74dcc32a2895a126d1e5f2cd3bbab499cac66db1",
                 "shasum": ""
             },
             "require": {
@@ -8486,7 +8486,7 @@
                 "issues": "https://github.com/facade/ignition/issues",
                 "source": "https://github.com/facade/ignition"
             },
-            "time": "2021-08-17T11:45:33+00:00"
+            "time": "2021-08-24T09:53:54+00:00"
         },
         {
             "name": "facade/ignition-contracts",
@@ -9092,16 +9092,16 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v5.8.0",
+            "version": "v5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "0c3c393462eada1233513664e2d22bb9f69ca393"
+                "reference": "63456f5c3e8c4bc52bd573e5c85674d64d84fd43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/0c3c393462eada1233513664e2d22bb9f69ca393",
-                "reference": "0c3c393462eada1233513664e2d22bb9f69ca393",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/63456f5c3e8c4bc52bd573e5c85674d64d84fd43",
+                "reference": "63456f5c3e8c4bc52bd573e5c85674d64d84fd43",
                 "shasum": ""
             },
             "require": {
@@ -9176,7 +9176,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-08-13T14:23:01+00:00"
+            "time": "2021-08-26T15:32:09+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/database/migrations/2020_08_03_151235_populate_settings_categories_table.php
+++ b/database/migrations/2020_08_03_151235_populate_settings_categories_table.php
@@ -20,7 +20,7 @@ class PopulateSettingsCategoriesTable extends Migration
                 'updated_at' => date('Y-m-d H:i:s'),
             ],
             [
-                'name' => 'Integração entre iEducar e iDiário',
+                'name' => 'Integração entre i-Educar e i-Diário',
                 'enabled' => true,
                 'created_at' => date('Y-m-d H:i:s'),
                 'updated_at' => date('Y-m-d H:i:s'),

--- a/database/migrations/2021_08_23_101322_atualiza_nomenclatura_de_configuracoes.php
+++ b/database/migrations/2021_08_23_101322_atualiza_nomenclatura_de_configuracoes.php
@@ -1,9 +1,11 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
-class AtualizaNomenclaturaDosCamposDaTelaDeConfiguracoes extends Migration
+class AtualizaNomenclaturaDeConfiguracoes extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2021_08_23_101322_atualiza_nomenclatura_de_configuracoes.php
+++ b/database/migrations/2021_08_23_101322_atualiza_nomenclatura_de_configuracoes.php
@@ -146,7 +146,7 @@ class AtualizaNomenclaturaDeConfiguracoes extends Migration
                     WHEN \'preregistration.title\' THEN \'Título da página inicial\'
                     WHEN \'preregistration.token\' THEN \'Token de segurança\'
                     WHEN \'preregistration.year\' THEN \'Ano vigente\'
-                    ELSE \'\'
+                    ELSE settings.description
                 END
             );
         ');

--- a/database/migrations/2021_08_23_102320_atualiza_nomenclatura_de_categorias.php
+++ b/database/migrations/2021_08_23_102320_atualiza_nomenclatura_de_categorias.php
@@ -19,7 +19,7 @@ class AtualizaNomenclaturaDeCategorias extends Migration
             SET name = (
                 CASE name
                     WHEN \'Integração entre iEducar e iDiário\' THEN \'Integração entre i-Educar e i-Diário\'
-                    ELSE \'\'
+                    ELSE settings_categories.name
                 END
             );
         ');

--- a/database/migrations/2021_08_23_102320_atualiza_nomenclatura_de_categorias.php
+++ b/database/migrations/2021_08_23_102320_atualiza_nomenclatura_de_categorias.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class AtualizaNomenclaturaDeCategorias extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::unprepared('
+            UPDATE settings_categories
+            SET name = (
+                CASE name
+                    WHEN \'Integração entre iEducar e iDiário\' THEN \'Integração entre i-Educar e i-Diário\'
+                    ELSE \'\'
+                END
+            );
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/ieducar/intranet/atendidos_cad.php
+++ b/ieducar/intranet/atendidos_cad.php
@@ -896,10 +896,7 @@ return new class extends clsCadastro {
         //pela antiga interface do cadastro de alunos.
 
         if (! $parentId && $this->_aluno['nm_' . $parentType]) {
-            $nome = Portabilis_String_Utils::toLatin1(
-                $this->_aluno['nm_' . $parentType],
-                ['transform' => true, 'escape' => false]
-            );
+            $nome = $this->_aluno['nm_' . $parentType];
 
             $inputHint = '<br /><b>Dica:</b> Foi informado o nome "' . $nome .
             '" no cadastro de aluno,<br />tente pesquisar esta pessoa ' .

--- a/ieducar/intranet/educar_documentacao_instituicao_cad.php
+++ b/ieducar/intranet/educar_documentacao_instituicao_cad.php
@@ -37,7 +37,7 @@ return new class extends clsCadastro {
 
         $this->campoTexto('titulo_documento', 'Título', $this->titulo_documento, 30, 50, false);
 
-        $this->campoArquivo('documento', 'Documentação padrão', $this->documento, 40, Portabilis_String_Utils::toLatin1('<span id=\'aviso_formato\'>São aceitos apenas arquivos no formato PDF com até 2MB.</span>', ['escape' => false]));
+        $this->campoArquivo('documento', 'Documentação padrão', $this->documento, 40, '<span id=\'aviso_formato\'>São aceitos apenas arquivos no formato PDF com até 2MB.</span>');
 
         $this->array_botao[] = 'Salvar';
         $this->array_botao_url_script[] = 'go(\'educar_instituicao_lst.php\')';

--- a/ieducar/intranet/educar_escolaridade_cad_pop.php
+++ b/ieducar/intranet/educar_escolaridade_cad_pop.php
@@ -58,7 +58,7 @@ return new class extends clsCadastro {
                            5 => 'Ensino médio',
                            6 => 'Superior'];
 
-        $options = ['label' => Portabilis_String_Utils::toLatin1('Escolaridade'), 'resources' => $resources, 'value' => $this->escolaridade];
+        $options = ['label' => 'Escolaridade', 'resources' => $resources, 'value' => $this->escolaridade];
         $this->inputsHelper()->select('escolaridade', $options);
     }
 

--- a/ieducar/intranet/educar_matricula_cad.php
+++ b/ieducar/intranet/educar_matricula_cad.php
@@ -91,7 +91,7 @@ return new class extends clsCadastro {
         }
 
         if ($this->ref_cod_turma_copiar_enturmacoes) {
-            $this->nome_url_sucesso = Portabilis_String_Utils::toLatin1('Gravar enturmações');
+            $this->nome_url_sucesso = 'Gravar enturmações';
             $url = route('enrollments.batch.enroll.index', ['schoolClass' => $this->ref_cod_turma_copiar_enturmacoes]);
         } else {
             $url = 'educar_aluno_det.php?cod_aluno=' . $this->ref_cod_aluno;
@@ -152,11 +152,11 @@ return new class extends clsCadastro {
         }
 
         if ($this->ref_cod_turma_copiar_enturmacoes) {
-            $this->nome_url_sucesso = Portabilis_String_Utils::toLatin1('Gravar enturmações');
+            $this->nome_url_sucesso ='Gravar enturmações';
         }
 
         $this->inputsHelper()->dynamic(['ano', 'instituicao', 'escola', 'curso', 'serie', 'turma']);
-        $this->inputsHelper()->date('data_matricula', ['label' => Portabilis_String_Utils::toLatin1('Data da matrícula'), 'placeholder' => 'dd/mm/yyyy', 'value' => date('d/m/Y')]);
+        $this->inputsHelper()->date('data_matricula', ['label' => 'Data da matrícula', 'placeholder' => 'dd/mm/yyyy', 'value' => date('d/m/Y')]);
         $this->inputsHelper()->textArea('observacoes', ['required' => false, 'label' => 'Observações']);
         $this->inputsHelper()->hidden('ano_em_andamento', ['value' => '1']);
 
@@ -164,7 +164,7 @@ return new class extends clsCadastro {
             $this->inputsHelper()->checkbox(
                 'dependencia',
                 [
-                    'label' => Portabilis_String_Utils::toLatin1('Matrícula de dependência?'),
+                    'label' => 'Matrícula de dependência?',
                     'value' => $this->dependencia
                 ]
             );
@@ -343,11 +343,11 @@ return new class extends clsCadastro {
         }
 
         if ($this->verificaAlunoFalecido()) {
-            $this->mensagem = Portabilis_String_Utils::toLatin1('Não é possível matricular alunos falecidos.');
+            $this->mensagem = 'Não é possível matricular alunos falecidos.';
         }
 
         if (!$this->permiteMatriculaSerieDestino() && $this->bloqueiaMatriculaSerieNaoSeguinte()) {
-            $this->mensagem = Portabilis_String_Utils::toLatin1('Não é possível matricular alunos em séries fora da sequência de enturmação.');
+            $this->mensagem = 'Não é possível matricular alunos em séries fora da sequência de enturmação.';
 
             return false;
         }
@@ -363,7 +363,7 @@ return new class extends clsCadastro {
             $bairro_aluno = $db->CampoUnico("select Upper(nome) from public.bairro where idbai = (select idbai from cadastro.endereco_pessoa where idpes = (select ref_idpes from pmieducar.aluno where cod_aluno = {$this->ref_cod_aluno}))");
 
             if (strcasecmp($bairro_aluno, $bairro_escola) != 0) {
-                $this->mensagem = Portabilis_String_Utils::toLatin1('O aluno deve morar no mesmo bairro da escola');
+                $this->mensagem = 'O aluno deve morar no mesmo bairro da escola';
 
                 return false;
             }
@@ -521,12 +521,12 @@ return new class extends clsCadastro {
                 $dentroPeriodoCorte = $serie->verificaPeriodoCorteEtarioDataNascimento($detPes['data_nasc'], $this->ano);
 
                 if ($bloquearMatriculaFaixaEtaria && !$dentroPeriodoCorte) {
-                    $this->mensagem = Portabilis_String_Utils::toLatin1('Não foi possível realizar a matrícula, pois a idade do aluno está fora da faixa etária da série');
+                    $this->mensagem = 'Não foi possível realizar a matrícula, pois a idade do aluno está fora da faixa etária da série');
 
                     return false;
                 } elseif ($alertaFaixaEtaria && !$dentroPeriodoCorte) {
                     echo '<script type="text/javascript">
-                        var msg = \'' . Portabilis_String_Utils::toLatin1('A idade do aluno encontra-se fora da faixa etária pré-definida na série, deseja continuar com a matrícula?') . '\';
+                        var msg = \'' . 'A idade do aluno encontra-se fora da faixa etária pré-definida na série, deseja continuar com a matrícula?' . '\';
                         if (!confirm(msg)) {
                           window.location = \'educar_aluno_det.php?cod_aluno=' . $this->ref_cod_aluno . '\';
                         } else {
@@ -826,7 +826,7 @@ return new class extends clsCadastro {
 
                 if (($countEscolasDiferentes > 0) && (!$reloadReserva)) {
                     echo '<script type="text/javascript">
-                      var msg = \'' . Portabilis_String_Utils::toLatin1('O aluno possui uma reserva de vaga em outra escola, deseja matricula-lo assim mesmo?') . '\';
+                      var msg = \'' . 'O aluno possui uma reserva de vaga em outra escola, deseja matricula-lo assim mesmo?' . '\';
                       if (!confirm(msg)) {
                         window.location = \'educar_aluno_det.php?cod_aluno=' . $this->ref_cod_aluno . '\';
                       } else {
@@ -981,7 +981,7 @@ return new class extends clsCadastro {
 
             return false;
         } else {
-            $this->mensagem = Portabilis_String_Utils::toLatin1('O ano (letivo) selecionado não está em andamento na escola selecionada.<br />');
+            $this->mensagem = 'O ano (letivo) selecionado não está em andamento na escola selecionada.<br />';
 
             return false;
         }
@@ -1020,7 +1020,7 @@ return new class extends clsCadastro {
                                                             WHERE serie.cod_serie = {$this->ref_cod_serie}");
 
         if ($matriculasDependencia >= $matriculasDependenciaPermitida) {
-            $this->mensagem = Portabilis_String_Utils::toLatin1("A regra desta série limita a quantidade de matrículas de dependência para {$matriculasDependenciaPermitida}.");
+            $this->mensagem = "A regra desta série limita a quantidade de matrículas de dependência para {$matriculasDependenciaPermitida}.";
 
             return false;
         }
@@ -1249,7 +1249,7 @@ return new class extends clsCadastro {
             );
         }
 
-        $this->mensagem = 'Exclus&atilde;o n&atilde;o realizada.<br />';
+        $this->mensagem = 'Exclusão não realizada.<br />';
 
         return false;
     }
@@ -1350,14 +1350,14 @@ return new class extends clsCadastro {
         if (!$dependencia) {
             // Caso quantidade de matrículas naquela turma seja maior ou igual que a capacidade da turma deve bloquear
             if ($this->_getQtdMatriculaTurma() >= $this->_getMaxAlunoTurma()) {
-                $this->mensagem = Portabilis_String_Utils::toLatin1('Não existem vagas disponíveis para essa turma!') . '<br/>';
+                $this->mensagem = 'Não existem vagas disponíveis para essa turma! <br/>';
 
                 return false;
             }
 
             // Caso a capacidade de alunos naquele turno seja menor ou igual ao ao número de alunos matrículados + alunos na reserva de vaga externa deve bloquear
             if ($this->_getMaxAlunoTurno() <= ($this->_getQtdAlunosFila() + $this->_getQtdMatriculaTurno())) {
-                $this->mensagem = Portabilis_String_Utils::toLatin1('Não existem vagas disponíveis para essa série/turno!') . '<br/>';
+                $this->mensagem = 'Não existem vagas disponíveis para essa série/turno! <br/>';
 
                 return false;
             }

--- a/ieducar/intranet/educar_matricula_cad.php
+++ b/ieducar/intranet/educar_matricula_cad.php
@@ -521,7 +521,7 @@ return new class extends clsCadastro {
                 $dentroPeriodoCorte = $serie->verificaPeriodoCorteEtarioDataNascimento($detPes['data_nasc'], $this->ano);
 
                 if ($bloquearMatriculaFaixaEtaria && !$dentroPeriodoCorte) {
-                    $this->mensagem = 'Não foi possível realizar a matrícula, pois a idade do aluno está fora da faixa etária da série');
+                    $this->mensagem = 'Não foi possível realizar a matrícula, pois a idade do aluno está fora da faixa etária da série';
 
                     return false;
                 } elseif ($alertaFaixaEtaria && !$dentroPeriodoCorte) {

--- a/ieducar/intranet/educar_matricula_ocorrencia_disciplinar_cad.php
+++ b/ieducar/intranet/educar_matricula_ocorrencia_disciplinar_cad.php
@@ -135,9 +135,9 @@ return new class extends clsCadastro {
 
         $this->campoCheck(
             'visivel_pais',
-            Portabilis_String_Utils::toLatin1('Visí­vel aos pais'),
+            'Visível aos pais',
             $this->visivel_pais,
-            Portabilis_String_Utils::toLatin1('Marque este campo, caso deseje que os pais do aluno possam visualizar tal ocorrência disciplinar.')
+            'Marque este campo, caso deseje que os pais do aluno possam visualizar tal ocorrência disciplinar.'
         );
     }
 
@@ -166,7 +166,7 @@ return new class extends clsCadastro {
                 $resposta = json_decode($this->enviaOcorrenciaNovoEducacao($cod_ocorrencia_disciplinar));
 
                 if (is_array($resposta->errors)) {
-                    echo Portabilis_String_Utils::toLatin1('Erro ao enviar ocorrencia disciplinar ao sistema externo: ' . $resposta->errors[0]);
+                    echo 'Erro ao enviar ocorrencia disciplinar ao sistema externo: ' . $resposta->errors[0];
                     die;
                 }
             }

--- a/ieducar/intranet/educar_raca_cad.php
+++ b/ieducar/intranet/educar_raca_cad.php
@@ -68,7 +68,7 @@ return new class extends clsCadastro {
                                 4 => 'Amarela',
                                 5 => 'Indígena'];
 
-        $options = ['label' => Portabilis_String_Utils::toLatin1('Raça educacenso'), 'resources' => $resources, 'value' => $this->raca_educacenso];
+        $options = ['label' => 'Raça educacenso', 'resources' => $resources, 'value' => $this->raca_educacenso];
         $this->inputsHelper()->select('raca_educacenso', $options);
     }
 

--- a/ieducar/intranet/educar_servidor_cad.php
+++ b/ieducar/intranet/educar_servidor_cad.php
@@ -430,7 +430,7 @@ return new class extends clsCadastro {
 
         $resources = [
             null => 'Selecione',
-            1 => Portabilis_String_Utils::toLatin1('Concluído'),
+            1 => 'Concluído',
             2 => 'Em andamento'
         ];
 

--- a/ieducar/intranet/educar_servidor_vinculo_turma_lst.php
+++ b/ieducar/intranet/educar_servidor_vinculo_turma_lst.php
@@ -47,11 +47,11 @@ return new class extends clsListagem {
         $this->inputsHelper()->dynamic(['ano', 'instituicao','escola','curso','serie', 'turma'], ['required' => false]);
 
         $resources_funcao = SelectOptions::funcoesExercidaServidor();
-        $options = ['label' => Portabilis_String_Utils::toLatin1('Função exercida'), 'resources' => $resources_funcao, 'value' => $this->funcao_exercida];
+        $options = ['label' =>'Função exercida', 'resources' => $resources_funcao, 'value' => $this->funcao_exercida];
         $this->inputsHelper()->select('funcao_exercida', $options);
 
         $resources_tipo = SelectOptions::tiposVinculoServidor();
-        $options = ['label' => Portabilis_String_Utils::toLatin1('Tipo do vínculo'), 'resources' => $resources_tipo, 'value' => $this->tipo_vinculo];
+        $options = ['label' => 'Tipo do vínculo', 'resources' => $resources_tipo, 'value' => $this->tipo_vinculo];
         $this->inputsHelper()->select('tipo_vinculo', $options);
 
         // Paginador

--- a/ieducar/intranet/educar_turma_cad.php
+++ b/ieducar/intranet/educar_turma_cad.php
@@ -631,9 +631,9 @@ return new class extends clsCadastro {
         $options = ['label' => 'Local de funcionamento diferenciado da turma', 'resources' => $resources, 'value' => $this->local_funcionamento_diferenciado, 'required' => false, 'size' => 70,];
         $this->inputsHelper()->select('local_funcionamento_diferenciado', $options);
 
-        $options = ['label' => Portabilis_String_Utils::toLatin1('Não informar esta turma no Censo escolar'),
+        $options = ['label' => 'Não informar esta turma no Censo escolar',
             'value' => $this->nao_informar_educacenso,
-            'label_hint' => Portabilis_String_Utils::toLatin1('Caso este campo seja selecionado, esta turma e todas as matrículas vinculadas a mesma, não serão informadas no arquivo de exportação do Censo escolar')];
+            'label_hint' => 'Caso este campo seja selecionado, esta turma e todas as matrículas vinculadas a mesma, não serão informadas no arquivo de exportação do Censo escolar'];
         $this->inputsHelper()->checkbox('nao_informar_educacenso', $options);
 
         $scripts = [
@@ -711,7 +711,7 @@ return new class extends clsCadastro {
                 false,
                 false,
                 $disableDefinirComponente,
-                Portabilis_String_Utils::toLatin1('Está opção poderá ser utilizada, somente se no cadastro da instituição o parâmetro de permissão estiver habilitado')
+                'Está opção poderá ser utilizada, somente se no cadastro da instituição o parâmetro de permissão estiver habilitado'
             );
 
             $this->escola_serie_disciplina = [];

--- a/ieducar/intranet/educar_usuario_cad.php
+++ b/ieducar/intranet/educar_usuario_cad.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\Employee;
 use App\Models\LegacyEmployee;
 use App\Services\ChangeUserPasswordService;
 use App\Services\ValidateUserPasswordService;
@@ -23,7 +22,6 @@ return new class extends clsCadastro {
     public $data_expiracao;
     public $escola;
     public $force_reset_password;
-    public $tempo_expira_senha;
 
     public function Inicializar()
     {
@@ -282,25 +280,6 @@ return new class extends clsCadastro {
             return false;
         }
 
-        // Em caso de unificação de pessoas o usuário perde os dados da tabela de funcionário.
-        // Neste caso verificamos se existe e caso não exista, é realizado um novo cadastro de funcionário para o usuário
-        /** @var Employee|null $legacyEmployee */
-        $legacyEmployee = LegacyEmployee::query()->find($this->ref_pessoa);
-
-        if ($legacyEmployee === null && empty($this->_senha)) {
-            $this->mensagem = 'Erro ao cadastrar funcionário, favor informe uma senha.<br>';
-            return false;
-        }
-
-        if ($legacyEmployee === null) {
-            $legacyEmployee = $this->cadastraNovoFuncionario();
-
-            if ($legacyEmployee === null) {
-                $this->mensagem = 'Erro ao cadastrar funcionário, favor entrar em contato com o suporte.<br>';
-                return false;
-            }
-        }
-
         // Ao editar não é necessário trocar a senha, então apenas quando algo
         // for informado é que a mesma será alterada.
         if ($this->_senha) {
@@ -371,47 +350,6 @@ return new class extends clsCadastro {
         $this->mensagem = 'Edição não realizada.<br>';
 
         return false;
-    }
-
-    /**
-     * @param string $dataReativaConta
-     * @return Employee|null
-     */
-    private function cadastraNovoFuncionario()
-    {
-        $objFuncionario = new clsPortalFuncionario(
-            $this->ref_pessoa,
-            $this->matricula,
-            $this->_senha,
-            $this->ativo,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            $this->ref_cod_funcionario_vinculo,
-            $this->tempo_expira_senha,
-            Portabilis_Date_Utils::brToPgSQL($this->data_expiracao),
-            null,
-            'NOW()',
-            $this->pessoa_logada,
-            0,
-            0,
-            null,
-            0,
-            null,
-            $this->email,
-            $this->matricula_interna
-        );
-
-        $objFuncionario->cadastra();
-
-        return Employee::query()->find($this->ref_pessoa);
     }
 
     public function Excluir()

--- a/ieducar/intranet/educar_usuario_cad.php
+++ b/ieducar/intranet/educar_usuario_cad.php
@@ -70,7 +70,6 @@ return new class extends clsCadastro {
             }
         }
 
-
         $nomeMenu = $retorno == 'Editar' ? $retorno : 'Cadastrar';
 
         $this->breadcrumb($nomeMenu . ' usuário', [

--- a/ieducar/intranet/educar_usuario_cad.php
+++ b/ieducar/intranet/educar_usuario_cad.php
@@ -70,17 +70,14 @@ return new class extends clsCadastro {
             }
         }
 
-        $this->url_cancelar = $retorno == 'Editar'
-            ? "educar_usuario_det.php?ref_pessoa={$this->ref_pessoa}"
-            : 'educar_usuario_lst.php';
-
-        $this->nome_url_cancelar = 'Cancelar';
 
         $nomeMenu = $retorno == 'Editar' ? $retorno : 'Cadastrar';
 
         $this->breadcrumb($nomeMenu . ' usuário', [
             url('intranet/educar_configuracoes_index.php') => 'Configurações',
         ]);
+
+        $this->montaBotoesDeAcao();
 
         return $retorno;
     }
@@ -211,6 +208,8 @@ return new class extends clsCadastro {
         }
 
         Portabilis_View_Helper_Application::loadJavascript($this, $scripts);
+
+        $this->montaBotoesDeAcao();
     }
 
     public function Novo()
@@ -455,5 +454,24 @@ return new class extends clsCadastro {
     {
         $validateUserPasswordService = app(ValidateUserPasswordService::class);
         $validateUserPasswordService->execute($password);
+    }
+
+    private function montaBotoesDeAcao(): void
+    {
+        $funcionario = (new clsPortalFuncionario($this->ref_pessoa))->detalhe();
+        $usuario = (new clsPmieducarUsuario($this->ref_pessoa))->detalhe();
+
+        $edita = false;
+        if ($funcionario !== false && $usuario !== false) {
+            $edita = true;
+        }
+
+        $this->url_cancelar = $edita
+            ? "educar_usuario_det.php?ref_pessoa={$this->ref_pessoa}"
+            : 'educar_usuario_lst.php';
+
+        $this->fexcluir = $edita;
+
+        $this->nome_url_cancelar = 'Cancelar';
     }
 };

--- a/ieducar/intranet/educar_usuario_cad.php
+++ b/ieducar/intranet/educar_usuario_cad.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Employee;
 use App\Models\LegacyEmployee;
 use App\Services\ChangeUserPasswordService;
 use App\Services\ValidateUserPasswordService;
@@ -22,6 +23,7 @@ return new class extends clsCadastro {
     public $data_expiracao;
     public $escola;
     public $force_reset_password;
+    public $tempo_expira_senha;
 
     public function Inicializar()
     {
@@ -278,6 +280,25 @@ return new class extends clsCadastro {
             return false;
         }
 
+        // Em caso de unificação de pessoas o usuário perde os dados da tabela de funcionário.
+        // Neste caso verificamos se existe e caso não exista, é realizado um novo cadastro de funcionário para o usuário
+        /** @var Employee|null $legacyEmployee */
+        $legacyEmployee = LegacyEmployee::query()->find($this->ref_pessoa);
+
+        if ($legacyEmployee === null && empty($this->_senha)) {
+            $this->mensagem = 'Erro ao cadastrar funcionário, favor informe uma senha.<br>';
+            return false;
+        }
+
+        if ($legacyEmployee === null) {
+            $legacyEmployee = $this->cadastraNovoFuncionario();
+
+            if ($legacyEmployee === null) {
+                $this->mensagem = 'Erro ao cadastrar funcionário, favor entrar em contato com o suporte.<br>';
+                return false;
+            }
+        }
+
         // Ao editar não é necessário trocar a senha, então apenas quando algo
         // for informado é que a mesma será alterada.
         if ($this->_senha) {
@@ -348,6 +369,47 @@ return new class extends clsCadastro {
         $this->mensagem = 'Edição não realizada.<br>';
 
         return false;
+    }
+
+    /**
+     * @param string $dataReativaConta
+     * @return Employee|null
+     */
+    private function cadastraNovoFuncionario()
+    {
+        $objFuncionario = new clsPortalFuncionario(
+            $this->ref_pessoa,
+            $this->matricula,
+            $this->_senha,
+            $this->ativo,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $this->ref_cod_funcionario_vinculo,
+            $this->tempo_expira_senha,
+            Portabilis_Date_Utils::brToPgSQL($this->data_expiracao),
+            null,
+            'NOW()',
+            $this->pessoa_logada,
+            0,
+            0,
+            null,
+            0,
+            null,
+            $this->email,
+            $this->matricula_interna
+        );
+
+        $objFuncionario->cadastra();
+
+        return Employee::query()->find($this->ref_pessoa);
     }
 
     public function Excluir()

--- a/ieducar/intranet/educar_usuario_cad.php
+++ b/ieducar/intranet/educar_usuario_cad.php
@@ -47,7 +47,6 @@ return new class extends clsCadastro {
 
                 $this->_senha = $this->senha;
                 $this->fexcluir = true;
-                $retorno = 'Editar';
             }
 
             if ($this->data_expiracao) {
@@ -66,6 +65,9 @@ return new class extends clsCadastro {
                 }
 
                 $this->fexcluir = $obj_permissoes->permissao_excluir(555, $this->pessoa_logada, 7);
+            }
+
+            if ($det_funcionario !== false && $registro !== false) {
                 $retorno = 'Editar';
             }
         }

--- a/ieducar/intranet/include/modules/clsModulesAuditoriaNota.inc.php
+++ b/ieducar/intranet/include/modules/clsModulesAuditoriaNota.inc.php
@@ -227,11 +227,8 @@ class clsModulesAuditoriaNota
 
         $objPessoa = new clsPessoa_($pessoaId);
         $detPessoa = $objPessoa->detalhe();
-        $nomePessoa = $detPessoa['nome'];
 
-        $nomePessoa = Portabilis_String_Utils::toLatin1($nomePessoa);
-
-        return $nomePessoa;
+        return $detPessoa['nome'];
     }
 
     private function getNomeTurma($turmaId)

--- a/ieducar/intranet/transporte_copia_rotas.php
+++ b/ieducar/intranet/transporte_copia_rotas.php
@@ -188,16 +188,16 @@ return new class extends clsCadastro {
                     }
                     $num++;
                 }
-                $this->mensagem = Portabilis_String_Utils::toLatin1('Cópia efetuada com sucesso');
+                $this->mensagem = 'Cópia efetuada com sucesso';
 
                 return true;
             } else {
-                $this->mensagem = Portabilis_String_Utils::toLatin1("A empresa já possuí­ rotas em {$this->ano_dest}");
+                $this->mensagem = "A empresa já possuí­ rotas em {$this->ano_dest}";
 
                 return false;
             }
         } else {
-            $this->mensagem = Portabilis_String_Utils::toLatin1("Não existe rotas em $this->ano_orig para essa empresa");
+            $this->mensagem ="Não existe rotas em $this->ano_orig para essa empresa";
 
             return false;
         }

--- a/ieducar/lib/Portabilis/Controller/ApiCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ApiCoreController.php
@@ -506,8 +506,6 @@ class ApiCoreController extends Core_Controller_Page_EditController
             $sqls = $this->sqlsForNumericSearch();
             $params = $this->sqlParams($numericQuery);
         } else {
-            $query = Portabilis_String_Utils::toLatin1($query, ['escape' => false]);
-
             $sqls = $this->sqlsForStringSearch();
             $params = $this->sqlParams($query);
         }

--- a/ieducar/lib/Portabilis/Controller/ApiCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ApiCoreController.php
@@ -421,10 +421,6 @@ class ApiCoreController extends Core_Controller_Page_EditController
         return Portabilis_String_Utils::toUtf8($str, $options);
     }
 
-    protected function toLatin1($str, $options = [])
-    {
-        return Portabilis_String_Utils::toLatin1($str, $options);
-    }
 
     protected function safeString($str, $transform = true)
     {
@@ -433,7 +429,7 @@ class ApiCoreController extends Core_Controller_Page_EditController
 
     protected function safeStringForDb($str)
     {
-        return $this->toLatin1($str);
+        return filter_var($str, FILTER_SANITIZE_ADD_SLASHES);;
     }
 
     protected function defaultSearchOptions()

--- a/ieducar/lib/Portabilis/Controller/ReportCoreController.php
+++ b/ieducar/lib/Portabilis/Controller/ReportCoreController.php
@@ -248,16 +248,15 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
      */
     public function onValidationError()
     {
-        $msg = Portabilis_String_Utils::toLatin1('O relatório não pode ser emitido, dica(s):') . '\n\n';
+        $msg = 'O relatório não pode ser emitido, dica(s): \n\n';
 
         foreach ($this->validationErrors as $e) {
             $error = $e['message'];
             $msg .= '- ' . $error . '\n';
         }
 
-        $msg .= '\n' . Portabilis_String_Utils::toLatin1('Por favor, verifique esta(s) situação(s) e tente novamente.');
+        $msg .= '\n Por favor, verifique esta(s) situação(s) e tente novamente.';
 
-        $msg = Portabilis_String_Utils::toLatin1($msg, ['escape' => false]);
         echo "<script type='text/javascript'>alert('$msg'); close();</script> ";
     }
 
@@ -271,9 +270,8 @@ class Portabilis_Controller_ReportCoreController extends Core_Controller_Page_Ed
     public function renderError($details = '')
     {
         $details = Portabilis_String_Utils::escape($details);
-        $msg = Portabilis_String_Utils::toLatin1('Ocorreu um erro ao emitir o relatório.') . '\n\n' . $details;
-
-        $msg = Portabilis_String_Utils::toLatin1($msg, ['escape' => false]);
+        $msg = 'Ocorreu um erro ao emitir o relatório. \n\n' . $details;
+        
         $msg = "<script type='text/javascript'>alert('$msg'); close();</script>";
 
         echo $msg;

--- a/ieducar/lib/Portabilis/String/Utils.php
+++ b/ieducar/lib/Portabilis/String/Utils.php
@@ -64,19 +64,6 @@ class Portabilis_String_Utils
         return $str;
     }
 
-    /**
-     * @deprecated
-     *
-     * @param string $str
-     * @param array  $options
-     *
-     * @return string
-     */
-    public static function toLatin1($str, $options = [])
-    {
-        return $str;
-    }
-
     public static function unaccent($str)
     {
         $fromEncoding = Portabilis_String_Utils::encoding($str);

--- a/ieducar/lib/Portabilis/View/Helper/Input/Numeric.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Numeric.php
@@ -51,7 +51,6 @@ class Portabilis_View_Helper_Input_Numeric extends Portabilis_View_Helper_Input_
         ];
 
         $inputOptions = $this->mergeOptions($options['options'], $defaultInputOptions);
-        $inputOptions['label'] = Portabilis_String_Utils::toLatin1($inputOptions['label'], ['escape' => false]);
 
         call_user_func_array([$this->viewInstance, 'campoNumero'], $inputOptions);
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/Beneficio.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/Beneficio.php
@@ -12,7 +12,7 @@ class Portabilis_View_Helper_Input_Resource_Beneficio extends Portabilis_View_He
             $resources = Portabilis_Array_Utils::setAsIdValue($resources, 'cod_aluno_beneficio', 'nm_beneficio');
         }
 
-        return $this->insertOption(null, Portabilis_String_Utils::toLatin1('Benefício'), $resources);
+        return $this->insertOption(null,'Benefício', $resources);
     }
 
     public function beneficio($options = [])

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/Religiao.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/Religiao.php
@@ -12,7 +12,7 @@ class Portabilis_View_Helper_Input_Resource_Religiao extends Portabilis_View_Hel
             $resources = Portabilis_Array_Utils::setAsIdValue($resources, 'cod_religiao', 'nm_religiao');
         }
 
-        return $this->insertOption(null, Portabilis_String_Utils::toLatin1('Religião'), $resources);
+        return $this->insertOption(null, 'Religião', $resources);
     }
 
     public function religiao($options = [])

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchBairro.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchBairro.php
@@ -25,7 +25,7 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchBairro extends Portabili
             $nome = $municipio['nome'];
             $zona = ($municipio['zona_localizacao'] == 1 ? 'Urbana' : 'Rural');
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]) . " / Zona $zona";
+            return $nome . " / Zona $zona";
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchCursoSuperior.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchCursoSuperior.php
@@ -21,9 +21,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchCursoSuperior extends Po
 
             $options = ['params' => $id, 'return_only' => 'first-row'];
             $curso_superior = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
-            $nome = $curso_superior['nome'];
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return $curso_superior['nome'];
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchEmpresa.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchEmpresa.php
@@ -7,9 +7,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchEmpresa extends Portabil
         if ($id) {
             $sql = 'select nome from modules.empresa_transporte_escolar, cadastro.pessoa where ref_idpes = idpes and cod_empresa_transporte_escolar = $1';
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchIes.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchIes.php
@@ -8,9 +8,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchIes extends Portabilis_V
             $sql = 'select ies_id || \' - \' || nome AS nome from modules.educacenso_ies where id = $1';
             $options = ['params' => $id, 'return_only' => 'first-row'];
             $ies = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
-            $nome = $ies['nome'];
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return $ies['nome'];
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchLogradouro.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchLogradouro.php
@@ -29,10 +29,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchLogradouro extends Porta
 
             $options = ['params' => $id, 'return_only' => 'first-row'];
             $resource = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
-            $tipo = Portabilis_String_Utils::toUtf8($resource['tipo_logradouro']);
-            $nome = Portabilis_String_Utils::toUtf8($resource['nome']);
 
-            return Portabilis_String_Utils::toLatin1($tipo . ' ' . $nome, ['transform' => true, 'escape' => false]);
+            return $resource['tipo_logradouro'] . ' ' . $resource['nome'];
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchMunicipio.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchMunicipio.php
@@ -7,11 +7,9 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchMunicipio extends Portab
         if ($id) {
             $sql = 'select nome, sigla_uf from public.municipio where idmun = $1';
             $options = ['params' => $id, 'return_only' => 'first-row'];
-            $municipio = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
-            $nome = $municipio['nome'];
-            $siglaUf = $municipio['sigla_uf'];
+            $query = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]) . " ($siglaUf)";
+            return $query['nome']  . " ({$query['sigla_uf']})";
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPais.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPais.php
@@ -7,9 +7,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchPais extends Portabilis_
         if ($id) {
             $sql = 'select nome from public.pais where idpais = $1';
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPaisSemBrasil.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPaisSemBrasil.php
@@ -7,9 +7,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchPaisSemBrasil extends Po
         if ($id) {
             $sql = 'select nome from public.pais where idpais = $1';
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
-
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPessoa.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPessoa.php
@@ -22,9 +22,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchPessoa extends Portabili
             ';
 
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPessoaj.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPessoaj.php
@@ -7,9 +7,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchPessoaj extends Portabil
         if ($id) {
             $sql = 'select nome from cadastro.pessoa where idpes = $1 and tipo=\'J\'';
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPonto.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchPonto.php
@@ -7,9 +7,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchPonto extends Portabilis
         if ($id) {
             $sql = 'select descricao from modules.ponto_transporte_escolar where cod_ponto_transporte_escolar = $1';
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchProjeto.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchProjeto.php
@@ -21,9 +21,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchProjeto extends Portabil
         if ($id) {
             $sql = 'select nome from pmieducar.projeto where cod_projeto = $1';
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchRota.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchRota.php
@@ -7,9 +7,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchRota extends Portabilis_
         if ($id) {
             $sql = 'select descricao from modules.rota_transporte_escolar where cod_rota_transporte_escolar = $1';
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchVeiculo.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Resource/SimpleSearchVeiculo.php
@@ -7,9 +7,8 @@ class Portabilis_View_Helper_Input_Resource_SimpleSearchVeiculo extends Portabil
         if ($id) {
             $sql = 'select (descricao || \',Placa: \' || placa) from modules.veiculo where cod_veiculo = $1';
             $options = ['params' => $id, 'return_only' => 'first-field'];
-            $nome = Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
 
-            return Portabilis_String_Utils::toLatin1($nome, ['transform' => true, 'escape' => false]);
+            return Portabilis_Utils_Database::fetchPreparedQuery($sql, $options);
         }
     }
 

--- a/ieducar/lib/Portabilis/View/Helper/Input/Select.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Select.php
@@ -25,7 +25,6 @@ class Portabilis_View_Helper_Input_Select extends Portabilis_View_Helper_Input_C
         ];
 
         $inputOptions = $this->mergeOptions($options['options'], $defaultInputOptions);
-        $inputOptions['label'] = Portabilis_String_Utils::toLatin1($inputOptions['label'], ['escape' => false]);
 
         call_user_func_array([$this->viewInstance, 'campoLista'], $inputOptions);
     }

--- a/ieducar/lib/Portabilis/View/Helper/Input/SimpleSearch.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/SimpleSearch.php
@@ -66,10 +66,7 @@ class Portabilis_View_Helper_Input_SimpleSearch extends Portabilis_View_Helper_I
     {
         $textHelperOptions = ['objectName' => $objectName];
 
-        $options['options']['placeholder'] = Portabilis_String_Utils::toLatin1(
-            $this->inputPlaceholder([]),
-            ['escape' => false]
-        );
+        $options['options']['placeholder'] = $this->inputPlaceholder([]);
 
         $this->inputsHelper()->text($attrName, $options['options'], $textHelperOptions);
     }

--- a/ieducar/lib/Portabilis/View/Helper/Input/Text.php
+++ b/ieducar/lib/Portabilis/View/Helper/Input/Text.php
@@ -29,7 +29,6 @@ class Portabilis_View_Helper_Input_Text extends Portabilis_View_Helper_Input_Cor
         ];
 
         $inputOptions = $this->mergeOptions($options['options'], $defaultInputOptions);
-        $inputOptions['label'] = Portabilis_String_Utils::toLatin1($inputOptions['label'], ['escape' => false]);
 
         call_user_func_array([$this->viewInstance, 'campoTexto'], $inputOptions);
         $this->fixupPlaceholder($inputOptions);

--- a/ieducar/modules/Api/Views/AlunoController.php
+++ b/ieducar/modules/Api/Views/AlunoController.php
@@ -388,7 +388,7 @@ class AlunoController extends ApiCoreController
 
     protected function saveSus($pessoaId)
     {
-        $sus = Portabilis_String_Utils::toLatin1($this->getRequest()->sus);
+        $sus = $this->getRequest()->sus;
         $sql = 'update cadastro.fisica set sus = $1 where idpes = $2';
 
         return $this->fetchPreparedQuery($sql, [$sus, $pessoaId]);
@@ -421,17 +421,17 @@ class AlunoController extends ApiCoreController
         $obj = new clsModulesFichaMedicaAluno();
 
         $obj->ref_cod_aluno = $id;
-        $obj->altura = Portabilis_String_Utils::toLatin1($this->getRequest()->altura);
-        $obj->peso = Portabilis_String_Utils::toLatin1($this->getRequest()->peso);
-        $obj->grupo_sanguineo = Portabilis_String_Utils::toLatin1($this->getRequest()->grupo_sanguineo);
+        $obj->altura = $this->getRequest()->altura;
+        $obj->peso = $this->getRequest()->peso;
+        $obj->grupo_sanguineo = $this->getRequest()->grupo_sanguineo;
         $obj->grupo_sanguineo = trim($obj->grupo_sanguineo);
-        $obj->fator_rh = Portabilis_String_Utils::toLatin1($this->getRequest()->fator_rh);
+        $obj->fator_rh = $this->getRequest()->fator_rh;
         $obj->alergia_medicamento = ($this->getRequest()->alergia_medicamento == 'on' ? 'S' : 'N');
-        $obj->desc_alergia_medicamento = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_alergia_medicamento);
+        $obj->desc_alergia_medicamento = $this->getRequest()->desc_alergia_medicamento;
         $obj->alergia_alimento = ($this->getRequest()->alergia_alimento == 'on' ? 'S' : 'N');
-        $obj->desc_alergia_alimento = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_alergia_alimento);
+        $obj->desc_alergia_alimento = $this->getRequest()->desc_alergia_alimento;
         $obj->doenca_congenita = ($this->getRequest()->doenca_congenita == 'on' ? 'S' : 'N');
-        $obj->desc_doenca_congenita = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_doenca_congenita);
+        $obj->desc_doenca_congenita = $this->getRequest()->desc_doenca_congenita;
         $obj->fumante = ($this->getRequest()->fumante == 'on' ? 'S' : 'N');
         $obj->doenca_caxumba = ($this->getRequest()->doenca_caxumba == 'on' ? 'S' : 'N');
         $obj->doenca_sarampo = ($this->getRequest()->doenca_sarampo == 'on' ? 'S' : 'N');
@@ -439,7 +439,7 @@ class AlunoController extends ApiCoreController
         $obj->doenca_catapora = ($this->getRequest()->doenca_catapora == 'on' ? 'S' : 'N');
         $obj->doenca_escarlatina = ($this->getRequest()->doenca_escarlatina == 'on' ? 'S' : 'N');
         $obj->doenca_coqueluche = ($this->getRequest()->doenca_coqueluche == 'on' ? 'S' : 'N');
-        $obj->doenca_outras = Portabilis_String_Utils::toLatin1($this->getRequest()->doenca_outras);
+        $obj->doenca_outras = $this->getRequest()->doenca_outras;
         $obj->epiletico = ($this->getRequest()->epiletico == 'on' ? 'S' : 'N');
         $obj->epiletico_tratamento = ($this->getRequest()->epiletico_tratamento == 'on' ? 'S' : 'N');
         $obj->hemofilico = ($this->getRequest()->hemofilico == 'on' ? 'S' : 'N');
@@ -448,25 +448,25 @@ class AlunoController extends ApiCoreController
         $obj->diabetico = ($this->getRequest()->diabetico == 'on' ? 'S' : 'N');
         $obj->insulina = ($this->getRequest()->insulina == 'on' ? 'S' : 'N');
         $obj->tratamento_medico = ($this->getRequest()->tratamento_medico == 'on' ? 'S' : 'N');
-        $obj->desc_tratamento_medico = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_tratamento_medico);
+        $obj->desc_tratamento_medico = $this->getRequest()->desc_tratamento_medico;
         $obj->medicacao_especifica = ($this->getRequest()->medicacao_especifica == 'on' ? 'S' : 'N');
-        $obj->desc_medicacao_especifica = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_medicacao_especifica);
+        $obj->desc_medicacao_especifica = $this->getRequest()->desc_medicacao_especifica;
         $obj->acomp_medico_psicologico = ($this->getRequest()->acomp_medico_psicologico == 'on' ? 'S' : 'N');
-        $obj->desc_acomp_medico_psicologico = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_acomp_medico_psicologico);
+        $obj->desc_acomp_medico_psicologico = $this->getRequest()->desc_acomp_medico_psicologico;
         $obj->acomp_medico_psicologico = ($this->getRequest()->acomp_medico_psicologico == 'on' ? 'S' : 'N');
-        $obj->desc_acomp_medico_psicologico = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_acomp_medico_psicologico);
+        $obj->desc_acomp_medico_psicologico = $this->getRequest()->desc_acomp_medico_psicologico;
         $obj->restricao_atividade_fisica = ($this->getRequest()->restricao_atividade_fisica == 'on' ? 'S' : 'N');
-        $obj->desc_restricao_atividade_fisica = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_restricao_atividade_fisica);
+        $obj->desc_restricao_atividade_fisica = $this->getRequest()->desc_restricao_atividade_fisica;
         $obj->fratura_trauma = ($this->getRequest()->fratura_trauma == 'on' ? 'S' : 'N');
-        $obj->desc_fratura_trauma = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_fratura_trauma);
+        $obj->desc_fratura_trauma = $this->getRequest()->desc_fratura_trauma;
         $obj->plano_saude = ($this->getRequest()->plano_saude == 'on' ? 'S' : 'N');
-        $obj->desc_plano_saude = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_plano_saude);
-        $obj->responsavel = Portabilis_String_Utils::toLatin1($this->getRequest()->responsavel);
-        $obj->responsavel_parentesco = Portabilis_String_Utils::toLatin1($this->getRequest()->responsavel_parentesco);
-        $obj->responsavel_parentesco_telefone = Portabilis_String_Utils::toLatin1($this->getRequest()->responsavel_parentesco_telefone);
-        $obj->responsavel_parentesco_celular = Portabilis_String_Utils::toLatin1($this->getRequest()->responsavel_parentesco_celular);
+        $obj->desc_plano_saude = $this->getRequest()->desc_plano_saude;
+        $obj->responsavel = $this->getRequest()->responsavel;
+        $obj->responsavel_parentesco = $this->getRequest()->responsavel_parentesco;
+        $obj->responsavel_parentesco_telefone = $this->getRequest()->responsavel_parentesco_telefone;
+        $obj->responsavel_parentesco_celular = $this->getRequest()->responsavel_parentesco_celular;
         $obj->aceita_hospital_proximo = ($this->getRequest()->aceita_hospital_proximo == 'on' ? 'S' : 'N');
-        $obj->desc_aceita_hospital_proximo = Portabilis_String_Utils::toLatin1($this->getRequest()->desc_aceita_hospital_proximo);
+        $obj->desc_aceita_hospital_proximo = $this->getRequest()->desc_aceita_hospital_proximo;
 
         return ($obj->existe() ? $obj->edita() : $obj->cadastra());
     }
@@ -478,7 +478,7 @@ class AlunoController extends ApiCoreController
         $obj->ref_cod_aluno = $id;
         $obj->moradia = $this->getRequest()->moradia;
         $obj->material = $this->getRequest()->material;
-        $obj->casa_outra = Portabilis_String_Utils::toLatin1($this->getRequest()->casa_outra);
+        $obj->casa_outra = $this->getRequest()->casa_outra;
         $obj->moradia_situacao = $this->getRequest()->moradia_situacao;
         $obj->quartos = $this->getRequest()->quartos;
         $obj->sala = $this->getRequest()->sala;
@@ -599,17 +599,17 @@ class AlunoController extends ApiCoreController
         $alunoEstadoId = preg_replace($mask['pattern'], $mask['replacement'], $alunoEstadoId);
         $aluno->aluno_estado_id = $alunoEstadoId;
 
-        $aluno->codigo_sistema = Portabilis_String_Utils::toLatin1($this->getRequest()->codigo_sistema);
-        $aluno->autorizado_um = Portabilis_String_Utils::toLatin1($this->getRequest()->autorizado_um);
-        $aluno->parentesco_um = Portabilis_String_Utils::toLatin1($this->getRequest()->parentesco_um);
-        $aluno->autorizado_dois = Portabilis_String_Utils::toLatin1($this->getRequest()->autorizado_dois);
-        $aluno->parentesco_dois = Portabilis_String_Utils::toLatin1($this->getRequest()->parentesco_dois);
-        $aluno->autorizado_tres = Portabilis_String_Utils::toLatin1($this->getRequest()->autorizado_tres);
-        $aluno->parentesco_tres = Portabilis_String_Utils::toLatin1($this->getRequest()->parentesco_tres);
-        $aluno->autorizado_quatro = Portabilis_String_Utils::toLatin1($this->getRequest()->autorizado_quatro);
-        $aluno->parentesco_quatro = Portabilis_String_Utils::toLatin1($this->getRequest()->parentesco_quatro);
-        $aluno->autorizado_cinco = Portabilis_String_Utils::toLatin1($this->getRequest()->autorizado_cinco);
-        $aluno->parentesco_cinco = Portabilis_String_Utils::toLatin1($this->getRequest()->parentesco_cinco);
+        $aluno->codigo_sistema = $this->getRequest()->codigo_sistema;
+        $aluno->autorizado_um = $this->getRequest()->autorizado_um;
+        $aluno->parentesco_um = $this->getRequest()->parentesco_um;
+        $aluno->autorizado_dois = $this->getRequest()->autorizado_dois;
+        $aluno->parentesco_dois = $this->getRequest()->parentesco_dois;
+        $aluno->autorizado_tres = $this->getRequest()->autorizado_tres;
+        $aluno->parentesco_tres = $this->getRequest()->parentesco_tres;
+        $aluno->autorizado_quatro = $this->getRequest()->autorizado_quatro;
+        $aluno->parentesco_quatro = $this->getRequest()->parentesco_quatro;
+        $aluno->autorizado_cinco = $this->getRequest()->autorizado_cinco;
+        $aluno->parentesco_cinco = $this->getRequest()->parentesco_cinco;
 
         // após cadastro não muda mais id pessoa
         if (is_null($id)) {
@@ -645,10 +645,10 @@ class AlunoController extends ApiCoreController
         $this->savePhoto($pessoaId);
 
         //documentos
-        $aluno->url_documento = Portabilis_String_Utils::toLatin1($this->getRequest()->url_documento);
+        $aluno->url_documento = $this->getRequest()->url_documento;
 
         //laudo medico
-        $aluno->url_laudo_medico = Portabilis_String_Utils::toLatin1($this->getRequest()->url_laudo_medico);
+        $aluno->url_laudo_medico = $this->getRequest()->url_laudo_medico;
 
         if (is_null($id)) {
             $id = $aluno->cadastra();
@@ -1687,7 +1687,7 @@ class AlunoController extends ApiCoreController
         $pt->ref_idpes_destino = $this->getRequest()->pessoaj_id;
         $pt->ref_cod_ponto_transporte_escolar = $this->getRequest()->transporte_ponto;
         $pt->ref_cod_rota_transporte_escolar = $this->getRequest()->transporte_rota;
-        $pt->observacao = Portabilis_String_Utils::toLatin1($this->getRequest()->transporte_observacao);
+        $pt->observacao = $this->getRequest()->transporte_observacao;
 
         return (is_null($id) ? $pt->cadastra() : $pt->edita());
     }

--- a/ieducar/modules/Api/Views/DiarioController.php
+++ b/ieducar/modules/Api/Views/DiarioController.php
@@ -36,7 +36,7 @@ class DiarioController extends ApiCoreController
         $valid = in_array($componenteCurricularId, $componentes);
 
         if (!$valid) {
-            throw new CoreExt_Exception(Portabilis_String_Utils::toLatin1("Componente curricular de código $componenteCurricularId não existe para essa turma/matrícula."));
+            throw new CoreExt_Exception("Componente curricular de código {$componenteCurricularId} não existe para essa turma/matrícula.");
         }
 
         return $valid;
@@ -138,7 +138,7 @@ class DiarioController extends ApiCoreController
 
             // validates service
             if (is_null($this->_boletimServiceInstances[$matriculaId])) {
-                throw new CoreExt_Exception(Portabilis_String_Utils::toLatin1("Não foi possivel instanciar o serviço boletim para a matrícula $matriculaId."));
+                throw new CoreExt_Exception("Não foi possivel instanciar o serviço boletim para a matrícula {$matriculaId}.");
             }
 
             return $this->_boletimServiceInstances[$matriculaId];
@@ -480,16 +480,15 @@ class DiarioController extends ApiCoreController
 
                     if (!empty($matriculaId)) {
                         if ($this->getRegra($matriculaId)->get('parecerDescritivo') != RegraAvaliacao_Model_TipoParecerDescritivo::ETAPA_COMPONENTE) {
-                            throw new CoreExt_Exception(Portabilis_String_Utils::toLatin1("A regra da turma $turmaId não permite lançamento de pareceres por etapa e componente."));
+                            throw new CoreExt_Exception("A regra da turma {$turmaId} não permite lançamento de pareceres por etapa e componente.");
                         }
 
                         foreach ($parecerTurmaAluno as $componenteCurricularId => $parecerTurmaAlunoComponente) {
                             if ($this->validateComponenteTurma($turmaId, $componenteCurricularId)) {
-                                $parecer = $parecerTurmaAlunoComponente['valor'];
 
                                 $parecerDescritivo = new Avaliacao_Model_ParecerDescritivoComponente([
                                     'componenteCurricular' => $componenteCurricularId,
-                                    'parecer' => Portabilis_String_Utils::toLatin1($parecer),
+                                    'parecer' => $parecerTurmaAlunoComponente['valor'],
                                     'etapa' => $etapa,
                                 ]);
 
@@ -516,16 +515,15 @@ class DiarioController extends ApiCoreController
 
                     if (!empty($matriculaId)) {
                         if ($this->getRegra($matriculaId)->get('parecerDescritivo') != RegraAvaliacao_Model_TipoParecerDescritivo::ANUAL_COMPONENTE) {
-                            throw new CoreExt_Exception(Portabilis_String_Utils::toLatin1("A regra da turma $turmaId não permite lançamento de pareceres anual por componente."));
+                            throw new CoreExt_Exception("A regra da turma {$turmaId} não permite lançamento de pareceres anual por componente.");
                         }
 
                         foreach ($parecerTurmaAluno as $componenteCurricularId => $parecerTurmaAlunoComponente) {
                             if ($this->validateComponenteCurricular($matriculaId, $componenteCurricularId)) {
-                                $parecer = $parecerTurmaAlunoComponente['valor'];
 
                                 $parecerDescritivo = new Avaliacao_Model_ParecerDescritivoComponente([
                                     'componenteCurricular' => $componenteCurricularId,
-                                    'parecer' => Portabilis_String_Utils::toLatin1($parecer),
+                                    'parecer' => $parecerTurmaAlunoComponente['valor'],
                                 ]);
 
                                 $this->serviceBoletim($turmaId, $alunoId)->addParecer($parecerDescritivo);
@@ -552,13 +550,11 @@ class DiarioController extends ApiCoreController
 
                     if (!empty($matriculaId)) {
                         if ($this->getRegra($matriculaId)->get('parecerDescritivo') != RegraAvaliacao_Model_TipoParecerDescritivo::ETAPA_GERAL) {
-                            throw new CoreExt_Exception(Portabilis_String_Utils::toLatin1("A regra da turma $turmaId não permite lançamento de pareceres por etapa geral."));
+                            throw new CoreExt_Exception("A regra da turma {$turmaId} não permite lançamento de pareceres por etapa geral.");
                         }
 
-                        $parecer = $parecerTurmaAluno['valor'];
-
                         $parecerDescritivo = new Avaliacao_Model_ParecerDescritivoGeral([
-                            'parecer' => Portabilis_String_Utils::toLatin1($parecer),
+                            'parecer' => $parecerTurmaAluno['valor'],
                             'etapa' => $etapa,
                         ]);
 
@@ -584,11 +580,11 @@ class DiarioController extends ApiCoreController
 
                     if (!empty($matriculaId)) {
                         if ($this->getRegra($matriculaId)->get('parecerDescritivo') != RegraAvaliacao_Model_TipoParecerDescritivo::ANUAL_GERAL) {
-                            throw new CoreExt_Exception(Portabilis_String_Utils::toLatin1("A regra da turma $turmaId não permite lançamento de pareceres anual geral."));
+                            throw new CoreExt_Exception("A regra da turma {$turmaId} não permite lançamento de pareceres anual geral.");
                         }
 
                         $parecerDescritivo = new Avaliacao_Model_ParecerDescritivoGeral([
-                            'parecer' => Portabilis_String_Utils::toLatin1($parecer),
+                            'parecer' => $parecer,
                         ]);
 
                         $this->serviceBoletim($turmaId, $alunoId)->addParecer($parecerDescritivo);

--- a/ieducar/modules/Api/Views/EducacensoExportController.php
+++ b/ieducar/modules/Api/Views/EducacensoExportController.php
@@ -281,7 +281,6 @@ class EducacensoExportController extends ApiCoreController
         $escola = Regulamentacao::handle($escola);
         $escola = EsferaAdministrativa::handle($escola);
 
-        $escola->conveniadaPoderPublico = null;
         $continuaExportacao = !in_array($escola->situacaoFuncionamento, [2, 3]);
 
         $data = [

--- a/ieducar/modules/Api/Views/EmpresaController.php
+++ b/ieducar/modules/Api/Views/EmpresaController.php
@@ -34,7 +34,7 @@ class EmpresaController extends ApiCoreController
 
         $empresa->ref_resp_idpes = $this->getRequest()->pessoa_id;
         $empresa->ref_idpes = $this->getRequest()->pessoaj_id;
-        $empresa->observacao = Portabilis_String_Utils::toLatin1($this->getRequest()->observacao);
+        $empresa->observacao = $this->getRequest()->observacao;
 
         return (is_null($id) ? $empresa->cadastra() : $empresa->edita());
     }

--- a/ieducar/modules/Api/Views/EscolaController.php
+++ b/ieducar/modules/Api/Views/EscolaController.php
@@ -356,7 +356,6 @@ class EscolaController extends ApiCoreController
     {
         // Caso a capacidade de alunos naquele turno seja menor ou igual ao ao número de alunos matrículados + alunos na reserva de vaga externa deve bloquear
         if ($this->_getMaxAlunoTurno($escolaId) <= ($this->_getQtdAlunosFila($escolaId) + $this->_getQtdMatriculaTurno($escolaId))) {
-            // $this->mensagem .= Portabilis_String_Utils::toLatin1("Não existem vagas disponíveis para essa série/turno!") . '<br/>';
             return false;
         }
 

--- a/ieducar/modules/Api/Views/MotoristaController.php
+++ b/ieducar/modules/Api/Views/MotoristaController.php
@@ -48,11 +48,11 @@ class MotoristaController extends ApiCoreController
         // após cadastro não muda mais id pessoa
         $motorista->ref_idpes = $this->getRequest()->pessoa_id;
         $motorista->cnh = $this->getRequest()->cnh;
-        $motorista->tipo_cnh = Portabilis_String_Utils::toLatin1($this->getRequest()->tipo_cnh);
+        $motorista->tipo_cnh = $this->getRequest()->tipo_cnh;
         $motorista->dt_habilitacao = Portabilis_Date_Utils::brToPgSQL($this->getRequest()->dt_habilitacao);
         $motorista->vencimento_cnh = Portabilis_Date_Utils::brToPgSQL($this->getRequest()->vencimento_cnh);
         $motorista->ref_cod_empresa_transporte_escolar = $this->getRequest()->empresa_id;
-        $motorista->observacao = Portabilis_String_Utils::toLatin1($this->getRequest()->observacao);
+        $motorista->observacao = $this->getRequest()->observacao;
 
         return (is_null($id) ? $motorista->cadastra() : $motorista->edita());
     }

--- a/ieducar/modules/Api/Views/PessoaController.php
+++ b/ieducar/modules/Api/Views/PessoaController.php
@@ -532,7 +532,7 @@ class PessoaController extends ApiCoreController
     {
         $pessoa = new clsPessoa_();
         $pessoa->idpes = $pessoaId;
-        $pessoa->nome = Portabilis_String_Utils::toLatin1($this->getRequest()->nome);
+        $pessoa->nome = $this->getRequest()->nome;
 
         $sql = 'select 1 from cadastro.pessoa WHERE idpes = $1 limit 1';
 

--- a/ieducar/modules/Api/Views/PessoatransporteController.php
+++ b/ieducar/modules/Api/Views/PessoatransporteController.php
@@ -31,7 +31,7 @@ class PessoatransporteController extends ApiCoreController
         $pt->ref_idpes_destino = $this->getRequest()->pessoaj_id;
         $pt->ref_cod_ponto_transporte_escolar = $this->getRequest()->ponto;
         $pt->ref_cod_rota_transporte_escolar = $this->getRequest()->rota;
-        $pt->observacao = Portabilis_String_Utils::toLatin1($this->getRequest()->observacao);
+        $pt->observacao = $this->getRequest()->observacao;
         $pt->turno = $this->getRequest()->turno;
 
         return (is_null($id) ? $pt->cadastra() : $pt->edita());

--- a/ieducar/modules/Api/Views/PontoController.php
+++ b/ieducar/modules/Api/Views/PontoController.php
@@ -22,7 +22,7 @@ class PontoController extends ApiCoreController
         }
 
         // após cadastro não muda mais id pessoa
-        $ponto->descricao = Portabilis_String_Utils::toLatin1($this->getRequest()->desc);
+        $ponto->descricao = $this->getRequest()->desc;
 
         $ponto->latitude = $this->getRequest()->latitude;
         $ponto->longitude = $this->getRequest()->longitude;

--- a/ieducar/modules/Api/Views/PreMatriculaController.php
+++ b/ieducar/modules/Api/Views/PreMatriculaController.php
@@ -42,29 +42,29 @@ class PreMatriculaController extends ApiCoreController
             $matriculaId = $this->getRequest()->matricula_id;
 
             // Dados do aluno
-            $nomeAluno = Portabilis_String_utils::toLatin1($this->getRequest()->nome_aluno);
+            $nomeAluno = $this->getRequest()->nome_aluno;
             $dataNascAluno = $this->getRequest()->data_nasc_aluno;
             $deficiencias = $this->getRequest()->deficiencias;
             $sexoAluno = $this->getRequest()->sexo_aluno;
             $alunoIdParametro = $this->getRequest()->aluno_id;
 
             // Dados responsaveis
-            $nomeMae = Portabilis_String_utils::toLatin1($this->getRequest()->nome_mae);
+            $nomeMae = $this->getRequest()->nome_mae;
             $cpfMae = $this->getRequest()->cpf_mae;
 
-            $nomeResponsavel = Portabilis_String_utils::toLatin1($this->getRequest()->nome_responsavel);
+            $nomeResponsavel = $this->getRequest()->nome_responsavel;
             $cpfResponsavel = $this->getRequest()->cpf_responsavel;
             $telefoneResponsavel = $this->getRequest()->telefone_responsavel;
 
             // Dados do endereço
             $cep = $this->getRequest()->cep;
-            $rua = Portabilis_String_utils::toLatin1($this->getRequest()->rua);
+            $rua = $this->getRequest()->rua;
             $numero = $this->getRequest()->numero;
-            $complemento = Portabilis_String_utils::toLatin1($this->getRequest()->complemento);
-            $bairro = Portabilis_String_utils::toLatin1($this->getRequest()->bairro);
-            $cidade = Portabilis_String_utils::toLatin1($this->getRequest()->cidade);
-            $estado = Portabilis_String_utils::toLatin1($this->getRequest()->estado);
-            $pais = Portabilis_String_utils::toLatin1($this->getRequest()->pais);
+            $complemento = $this->getRequest()->complemento;
+            $bairro = $this->getRequest()->bairro;
+            $cidade = $this->getRequest()->cidade;
+            $estado = $this->getRequest()->estado;
+            $pais = $this->getRequest()->pais;
 
             $this->atualizaPreMatricula($matriculaId, $escolaId);
 
@@ -207,17 +207,17 @@ class PreMatriculaController extends ApiCoreController
             }
 
             // Dados do aluno
-            $nomeAluno = Portabilis_String_utils::toLatin1($this->getRequest()->nome_aluno);
+            $nomeAluno = $this->getRequest()->nome_aluno;
             $dataNascAluno = $this->getRequest()->data_nasc_aluno;
             $deficiencias = $this->getRequest()->deficiencias;
             $sexoAluno = $this->getRequest()->sexo_aluno;
 
             // Dados responsaveis
-            $nomeMae = Portabilis_String_utils::toLatin1($this->getRequest()->nome_mae);
+            $nomeMae = $this->getRequest()->nome_mae;
             $cpfMae = $this->getRequest()->cpf_mae;
             $telefoneMae = $this->getRequest()->telefone_mae;
 
-            $nomeResponsavel = Portabilis_String_utils::toLatin1($this->getRequest()->nome_responsavel);
+            $nomeResponsavel = $this->getRequest()->nome_responsavel;
             $cpfResponsavel = $this->getRequest()->cpf_responsavel;
             $telefoneResponsavel = $this->getRequest()->telefone_responsavel;
 

--- a/ieducar/modules/Api/Views/ReportController.php
+++ b/ieducar/modules/Api/Views/ReportController.php
@@ -114,7 +114,7 @@ class ReportController extends ApiCoreController
             $boletimProfessorReport->addArg('curso', (int)$this->getRequest()->curso_id);
             $boletimProfessorReport->addArg('serie', (int)$this->getRequest()->serie_id);
             $boletimProfessorReport->addArg('turma', (int)$this->getRequest()->turma_id);
-            $boletimProfessorReport->addArg('professor', Portabilis_String_Utils::toLatin1($this->getRequest()->professor));
+            $boletimProfessorReport->addArg('professor', $this->getRequest()->professor);
             $boletimProfessorReport->addArg('disciplina', (int)$this->getRequest()->componente_curricular_id);
             $boletimProfessorReport->addArg('orientacao', 2);
             $boletimProfessorReport->addArg('situacao', (int) $this->getRequest()->situacao ?? 0);

--- a/ieducar/modules/Api/Views/RotaController.php
+++ b/ieducar/modules/Api/Views/RotaController.php
@@ -32,7 +32,7 @@ class RotaController extends ApiCoreController
         $rota->cod_rota_transporte_escolar = $id;
 
         // após cadastro não muda mais id pessoa
-        $rota->descricao = Portabilis_String_Utils::toLatin1($this->getRequest()->desc);
+        $rota->descricao = $this->getRequest()->desc;
         $rota->ref_idpes_destino = $this->getRequest()->pessoaj_id;
         $rota->ano = $this->getRequest()->ano;
         $rota->tipo_rota = $this->getRequest()->tipo_rota;

--- a/ieducar/modules/Api/Views/UsuarioExportController.php
+++ b/ieducar/modules/Api/Views/UsuarioExportController.php
@@ -24,8 +24,8 @@ class UsuarioExportController extends ApiCoreController
         $csv .= 'E-mail,';
         $csv .= 'CPF,';
         $csv .= 'Status,';
-        $csv .= Portabilis_String_Utils::toLatin1('Tipo_usuário,');
-        $csv .= Portabilis_String_Utils::toLatin1('Instituição,');
+        $csv .= 'Tipo_usuário,';
+        $csv .= 'Instituição,';
         $csv .= 'Escola,';
         $csv .= PHP_EOL;
 

--- a/ieducar/modules/Api/Views/VeiculoController.php
+++ b/ieducar/modules/Api/Views/VeiculoController.php
@@ -27,11 +27,11 @@ class VeiculoController extends ApiCoreController
         $veiculo->cod_veiculo = $id;
 
         // após cadastro não muda mais id pessoa
-        $veiculo->descricao = Portabilis_String_Utils::toLatin1($this->getRequest()->descricao);
-        $veiculo->placa = Portabilis_String_Utils::toLatin1($this->getRequest()->placa);
+        $veiculo->descricao = $this->getRequest()->descricao;
+        $veiculo->placa = $this->getRequest()->placa;
         $veiculo->renavam = $this->getRequest()->renavam;
         $veiculo->chassi = $this->getRequest()->chassi;
-        $veiculo->marca = Portabilis_String_Utils::toLatin1($this->getRequest()->marca);
+        $veiculo->marca = $this->getRequest()->marca;
         $veiculo->passageiros = $this->getRequest()->passageiros;
         $veiculo->ano_fabricacao = $this->getRequest()->ano_fabricacao;
         $veiculo->ano_modelo = $this->getRequest()->ano_modelo;
@@ -40,10 +40,10 @@ class VeiculoController extends ApiCoreController
         $veiculo->exclusivo_transporte_escolar = ($this->getRequest()->exclusivo_transporte_escolar == 'on' ? 'S' : 'N');
         $veiculo->adaptado_necessidades_especiais = ($this->getRequest()->adaptado_necessidades_especiais == 'on' ? 'S' : 'N');
         $veiculo->ativo = ($this->getRequest()->ativo == 'on' ? 'S' : 'N');
-        $veiculo->descricao_inativo = Portabilis_String_Utils::toLatin1($this->getRequest()->descricao_inativo);
+        $veiculo->descricao_inativo = $this->getRequest()->descricao_inativo;
         $veiculo->ref_cod_empresa_transporte_escolar = $this->getRequest()->empresa_id;
         $veiculo->ref_cod_motorista = $this->getRequest()->motorista_id;
-        $veiculo->observacao = Portabilis_String_Utils::toLatin1($this->getRequest()->observacao);
+        $veiculo->observacao = $this->getRequest()->observacao;
 
         return (is_null($id) ? $veiculo->cadastra() : $veiculo->edita());
     }

--- a/ieducar/modules/DynamicInput/Views/MatriculaController.php
+++ b/ieducar/modules/DynamicInput/Views/MatriculaController.php
@@ -12,7 +12,7 @@ class MatriculaController extends ApiCoreController
     {
         if ($this->canGetMatriculas()) {
             $matriculas = new clsPmieducarMatricula();
-            $matriculas->setOrderby('sequencial_fechamento , translate(nome,\''.Portabilis_String_Utils::toLatin1(åáàãâäéèêëíìîïóòõôöúùüûçÿýñÅÁÀÃÂÄÉÈÊËÍÌÎÏÓÒÕÔÖÚÙÛÜÇÝÑ).'\', \''.Portabilis_String_Utils::toLatin1(aaaaaaeeeeiiiiooooouuuucyynAAAAAAEEEEIIIIOOOOOUUUUCYN).'\') ');
+            $matriculas->setOrderby('sequencial_fechamento , translate(nome,\''. 'åáàãâäéèêëíìîïóòõôöúùüûçÿýñÅÁÀÃÂÄÉÈÊËÍÌÎÏÓÒÕÔÖÚÙÛÜÇÝÑ'.'\', \''. 'aaaaaaeeeeiiiiooooouuuucyynAAAAAAEEEEIIIIOOOOOUUUUCYN'.'\') ');
             $matriculas = $matriculas->lista(
                 null,
                 null,

--- a/ieducar/modules/DynamicInput/Views/TransferidoController.php
+++ b/ieducar/modules/DynamicInput/Views/TransferidoController.php
@@ -12,7 +12,7 @@ class TransferidoController extends ApiCoreController
     {
         if ($this->canGetTransferido()) {
             $matriculas = new clsPmieducarMatricula();
-            $matriculas->setOrderby('sequencial_fechamento , translate(nome,\''.Portabilis_String_Utils::toLatin1(åáàãâäéèêëíìîïóòõôöúùüûçÿýñÅÁÀÃÂÄÉÈÊËÍÌÎÏÓÒÕÔÖÚÙÛÜÇÝÑ).'\', \''.Portabilis_String_Utils::toLatin1(aaaaaaeeeeiiiiooooouuuucyynAAAAAAEEEEIIIIOOOOOUUUUCYN).'\') ');
+            $matriculas->setOrderby('sequencial_fechamento , translate(nome,\''.'åáàãâäéèêëíìîïóòõôöúùüûçÿýñÅÁÀÃÂÄÉÈÊËÍÌÎÏÓÒÕÔÖÚÙÛÜÇÝÑ'.'\', \''. 'aaaaaaeeeeiiiiooooouuuucyynAAAAAAEEEEIIIIOOOOOUUUUCYN'.'\') ');
             $matriculas = $matriculas->lista_transferidos(
                 null,
                 null,

--- a/ieducar/modules/HistoricoEscolar/Views/ProcessamentoApiController.php
+++ b/ieducar/modules/HistoricoEscolar/Views/ProcessamentoApiController.php
@@ -968,7 +968,7 @@ class ProcessamentoApiController extends Core_Controller_Page_EditController
     {
         $sql = 'select nm_serie from pmieducar.serie where cod_serie = $1';
 
-        return Portabilis_String_Utils::toLatin1(Portabilis_Utils_Database::selectField($sql, $serieId));
+        return Portabilis_Utils_Database::selectField($sql, $serieId);
     }
 
     protected function getSequencial($alunoId, $ano, $matriculaId)

--- a/ieducar/modules/HistoricoEscolar/Views/ProcessamentoController.php
+++ b/ieducar/modules/HistoricoEscolar/Views/ProcessamentoController.php
@@ -74,8 +74,8 @@ class ProcessamentoController extends Portabilis_Controller_Page_ListController
         if ($this->validaControlePosicaoHistorico()) {
             $campoPosicao = '
             <tr class=\'tr_posicao\'>
-                <td><label for=\'posicao\'>' . Portabilis_String_Utils::toLatin1('Posição') . ' *</label><br>
-                <sub style=\'vertical-align:top;\'>' . Portabilis_String_Utils::toLatin1('Informe a coluna equivalente a série/ano/etapa a qual o histórico pertence. Ex.: 1º ano informe 1, 2º ano informe 2') . '</sub></td>
+                <td><label for=\'posicao\'>' . 'Posição' . ' *</label><br>
+                <sub style=\'vertical-align:top;\'>' . 'Informe a coluna equivalente a série/ano/etapa a qual o histórico pertence. Ex.: 1º ano informe 1, 2º ano informe 2' . '</sub></td>
                 <td colspan=\'2\'><input type=\'text\' id=\'posicao\' name=\'posicao\' class=\'obrigatorio disable-on-search clear-on-change-curso validates-value-is-numeric\'></input></td>
             </tr>';
         }

--- a/ieducar/modules/TransporteEscolar/Views/EmpresaController.php
+++ b/ieducar/modules/TransporteEscolar/Views/EmpresaController.php
@@ -77,7 +77,7 @@ class EmpresaController extends Portabilis_Controller_Page_EditController
 
         // observações
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('observacao')),
+            'label' => $this->_getLabel('observacao'),
             'required' => false,
             'size' => 50,
             'max_length' => 253

--- a/ieducar/modules/TransporteEscolar/Views/ItinerarioController.php
+++ b/ieducar/modules/TransporteEscolar/Views/ItinerarioController.php
@@ -59,7 +59,7 @@ class ItinerarioController extends Portabilis_Controller_Page_EditController
 
         // descricao
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('descricao')),
+            'label' => $this->_getLabel('descricao'),
             'disabled' => true,
             'size' => 50,
             'max_length' => 50

--- a/ieducar/modules/TransporteEscolar/Views/MotoristaController.php
+++ b/ieducar/modules/TransporteEscolar/Views/MotoristaController.php
@@ -96,8 +96,7 @@ class MotoristaController extends Portabilis_Controller_Page_EditController
             'label' => $this->_getLabel('cnh'),
             'max_length' => 15,
             'size' => 15,
-            'placeholder' => Portabilis_String_Utils::toLatin1('Número da CNH'),
-            'required' => false
+            'placeholder' => 'Número da CNH'
         ];
         $this->inputsHelper()->integer('cnh', $options);
 
@@ -113,7 +112,7 @@ class MotoristaController extends Portabilis_Controller_Page_EditController
 
         // Vencimento
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('dt_habilitacao')),
+            'label' => $this->_getLabel('dt_habilitacao'),
             'required' => false,
             'size' => 10,
             'placeholder' => ''
@@ -122,7 +121,7 @@ class MotoristaController extends Portabilis_Controller_Page_EditController
 
         // Habilitação
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('vencimento_cnh')),
+            'label' => $this->_getLabel('vencimento_cnh'),
             'required' => false,
             'size' => 10,
             'placeholder' => ''
@@ -131,14 +130,14 @@ class MotoristaController extends Portabilis_Controller_Page_EditController
 
         // Codigo da empresa
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('ref_cod_empresa_transporte_escolar')),
+            'label' => $this->_getLabel('ref_cod_empresa_transporte_escolar'),
             'required' => true
         ];
         $this->inputsHelper()->simpleSearchEmpresa('ref_cod_empresa_transporte_escolarf', $options);
 
         // observações
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('observacao')),
+            'label' => $this->_getLabel('observacao'),
             'required' => false,
             'size' => 50,
             'max_length' => 255

--- a/ieducar/modules/TransporteEscolar/Views/PontoController.php
+++ b/ieducar/modules/TransporteEscolar/Views/PontoController.php
@@ -62,7 +62,7 @@ class PontoController extends Portabilis_Controller_Page_EditController
 
         // descricao
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('desc')),
+            'label' => $this->_getLabel('desc'),
             'required' => true,
             'size' => 50,
             'max_length' => 70

--- a/ieducar/modules/TransporteEscolar/Views/RotaController.php
+++ b/ieducar/modules/TransporteEscolar/Views/RotaController.php
@@ -77,7 +77,7 @@ class RotaController extends Portabilis_Controller_Page_EditController
 
         // ano
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('ano')),
+            'label' => $this->_getLabel('ano'),
             'required' => true,
             'size' => 5,
             'max_length' => 4
@@ -95,7 +95,7 @@ class RotaController extends Portabilis_Controller_Page_EditController
 
         // descricao
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('desc')),
+            'label' => $this->_getLabel('desc'),
             'required' => true,
             'size' => 50,
             'max_length' => 50

--- a/ieducar/modules/TransporteEscolar/Views/VeiculoController.php
+++ b/ieducar/modules/TransporteEscolar/Views/VeiculoController.php
@@ -149,7 +149,7 @@ class VeiculoController extends Portabilis_Controller_Page_EditController
 
         // descrição
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('descricao')),
+            'label' => $this->_getLabel('descricao'),
             'required' => true,
             'size' => 50,
             'max_length' => 255
@@ -158,7 +158,7 @@ class VeiculoController extends Portabilis_Controller_Page_EditController
 
         //placa
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('placa')),
+            'label' => $this->_getLabel('placa'),
             'required' => false,
             'size' => 10,
             'max_length' => 10
@@ -167,7 +167,7 @@ class VeiculoController extends Portabilis_Controller_Page_EditController
 
         //renavam
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('renavam')),
+            'label' => $this->_getLabel('renavam'),
             'required' => false,
             'size' => 15,
             'max_length' => 15
@@ -176,7 +176,7 @@ class VeiculoController extends Portabilis_Controller_Page_EditController
 
         //chassi
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('chassi')),
+            'label' => $this->_getLabel('chassi'),
             'required' => false,
             'size' => 30,
             'max_length' => 30
@@ -185,7 +185,7 @@ class VeiculoController extends Portabilis_Controller_Page_EditController
 
         //marca
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('marca')),
+            'label' => $this->_getLabel('marca'),
             'required' => false,
             'size' => 50,
             'max_length' => 50
@@ -225,11 +225,10 @@ class VeiculoController extends Portabilis_Controller_Page_EditController
         // Malha
         $malhas = [
             null => 'Selecione uma Malha',
-            'A' => Portabilis_String_Utils::toLatin1('Aquaviária/Embarcação'),
-            'F' => Portabilis_String_Utils::toLatin1('Ferroviária'),
-            'R' => Portabilis_String_Utils::toLatin1('Rodoviária')
+            'A' => 'Aquaviária/Embarcação',
+            'F' => 'Ferroviária',
+            'R' => 'Rodoviária'
         ];
-
         $options = [
             'label' => $this->_getLabel('malha'),
             'resources' => $malhas,
@@ -258,20 +257,20 @@ class VeiculoController extends Portabilis_Controller_Page_EditController
         $this->inputsHelper()->select('tipo', $options);
 
         // Exclusivo transporte escolar
-        $options = ['label' => Portabilis_String_Utils::toLatin1($this->_getLabel('exclusivo_transporte_escolar'))];
+        $options = ['label' => $this->_getLabel('exclusivo_transporte_escolar')];
         $this->inputsHelper()->checkbox('exclusivo_transporte_escolar', $options);
 
         // Adaptado a necessidades especiais
-        $options = ['label' => Portabilis_String_Utils::toLatin1($this->_getLabel('adaptado_necessidades_especiais'))];
+        $options = ['label' => $this->_getLabel('adaptado_necessidades_especiais')];
         $this->inputsHelper()->checkbox('adaptado_necessidades_especiais', $options);
 
         // Ativo
-        $options = ['label' => Portabilis_String_Utils::toLatin1($this->_getLabel('ativo')), 'value' => 'on'];
+        $options = ['label' => $this->_getLabel('ativo'), 'value' => 'on'];
         $this->inputsHelper()->checkbox('ativo', $options);
 
         // descricao_inativo
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('descricao_inativo')),
+            'label' => $this->_getLabel('descricao_inativo'),
             'required' => false,
             'size' => 50,
             'max_length' => 155
@@ -279,16 +278,16 @@ class VeiculoController extends Portabilis_Controller_Page_EditController
         $this->inputsHelper()->textArea('descricao_inativo', $options);
 
         // Codigo da empresa
-        $options = ['label' => Portabilis_String_Utils::toLatin1($this->_getLabel('empresa')), 'required' => true];
+        $options = ['label' => $this->_getLabel('empresa'), 'required' => true];
         $this->inputsHelper()->simpleSearchEmpresa('empresa', $options);
 
         // Codigo do motorista
-        $options = ['label' => Portabilis_String_Utils::toLatin1($this->_getLabel('motorista')), 'required' => false];
+        $options = ['label' => $this->_getLabel('motorista'), 'required' => false];
         $this->inputsHelper()->simpleSearchMotorista('motorista', $options);
 
         // observações
         $options = [
-            'label' => Portabilis_String_Utils::toLatin1($this->_getLabel('observacao')),
+            'label' => $this->_getLabel('observacao'),
             'required' => false,
             'size' => 50,
             'max_length' => 255

--- a/src/Modules/Reports/QueryFactory/MovimentoGeralAlunosAdmitidosQueryFactory.php
+++ b/src/Modules/Reports/QueryFactory/MovimentoGeralAlunosAdmitidosQueryFactory.php
@@ -19,7 +19,7 @@ class MovimentoGeralAlunosAdmitidosQueryFactory extends QueryFactory
     ];
 
     protected $query = <<<'SQL'
-        select 
+        select
             m.cod_matricula,
             pessoa.nome,
             turma.nm_turma
@@ -44,7 +44,7 @@ class MovimentoGeralAlunosAdmitidosQueryFactory extends QueryFactory
                     modules.config_movimento_geral
                 inner join pmieducar.serie
                     on serie.cod_serie = config_movimento_geral.ref_cod_serie
-                where true 
+                where true
                     and (case
                         when :seleciona_curso = 0 then
                             true
@@ -53,7 +53,7 @@ class MovimentoGeralAlunosAdmitidosQueryFactory extends QueryFactory
                     end)
             )
             and mt.sequencial = 1
-            and (coalesce(mt.data_enturmacao, m.data_cadastro) > :data_inicial::date and coalesce(mt.data_enturmacao, m.data_cadastro) < data_final::date)
+            and (coalesce(mt.data_enturmacao, m.data_cadastro) > :data_inicial::date and coalesce(mt.data_enturmacao, m.data_cadastro) < :data_final::date)
         order by
             pessoa.nome asc
 SQL;

--- a/src/Modules/Reports/QueryFactory/MovimentoGeralQueryFactory.php
+++ b/src/Modules/Reports/QueryFactory/MovimentoGeralQueryFactory.php
@@ -335,7 +335,7 @@ class MovimentoGeralQueryFactory extends QueryFactory
                         select ref_cod_serie
                         from modules.config_movimento_geral
                         inner join pmieducar.serie on serie.cod_serie = config_movimento_geral.ref_cod_serie
-                        where true 
+                        where true
                             and (case
                                 when :seleciona_curso = 0 then
                                     true
@@ -344,7 +344,7 @@ class MovimentoGeralQueryFactory extends QueryFactory
                             end)
                     )
                     and mt.sequencial = 1
-                    and coalesce(mt.data_enturmacao, m.data_cadastro) between :data_inicial::date and :data_final::date
+                    and (coalesce(mt.data_enturmacao, m.data_cadastro) > :data_inicial::date and coalesce(mt.data_enturmacao, m.data_cadastro) < :data_final::date)
             ) as admitidos,
             (
                 select count(cod_matricula)


### PR DESCRIPTION
**Educacenso:**

- Remove implementação que deixa sempre o campo conveniadaPoderPublico em branco. 

**Melhorias:**

- Ajustes de nomenclatura em "Configurações do Sistema".

**Bugs:**

- Faz checagem de funcionário e usuário para determinar ação correta do sistema.
- Corrige SQL e unifica regra na consulta do Movimento Geral.
- Corrige situação em que os botões de ação sumiam quando a tela apresentava erro.
- Garante cópia do tipo de falta correto.

**Desenvolvimento:**

- Remove função `toLatin1`.