### PR TITLE
[2.6] Ativa cadastros de tipos do abandono

### DIFF
--- a/database/migrations/2021_08_27_233435_update_abandono_tipo.php
+++ b/database/migrations/2021_08_27_233435_update_abandono_tipo.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class UpdateAbandonoTipo extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::unprepared(
+            'UPDATE pmieducar.abandono_tipo abandonoTipo SET ativo = 1 
+            WHERE abandonoTipo.ativo IS NULL;'
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
PR original https://github.com/portabilis/i-educar/pull/781.

> Corrigindo tabela pmieducar.abandono_tipo para contemplar o valor do atributo ativo, pois sendo null, o campo nome não estava sendo retornado na tela de cadastro de abandono.

