### PR TITLE
[2.6] Torna o título do i-Educar padrão

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -77,8 +77,30 @@ class Controller extends BaseController
         }
 
         View::share('menu', $menu);
-        View::share('title', '');
+        View::share('title', $this->getPageTitle());
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    private function getPageTitle()
+    {
+        if (isset($this->title)) {
+            return $this->title;
+        }
+
+        if (isset($this->_title)) {
+            return $this->_title;
+        }
+
+        if (isset($this->titulo)) {
+            return $this->titulo;
+        }
+
+        if (isset($this->_titulo)) {
+            return $this->_titulo;
+        }
     }
 }

--- a/ieducar/intranet/educar_avancar_mod_cad.php
+++ b/ieducar/intranet/educar_avancar_mod_cad.php
@@ -363,7 +363,7 @@ return new class extends clsCadastro {
 
     public function Formular()
     {
-        $this->titulo = 'i-Educar';
+        $this->titulo = 'Rematrícula automática';
         $this->processoAp = '845';
     }
 };

--- a/ieducar/intranet/educar_usuario_lst.php
+++ b/ieducar/intranet/educar_usuario_lst.php
@@ -144,7 +144,7 @@ return new class extends clsListagem {
 
     public function Formular()
     {
-        $this->title = 'Usu&aacute;rios!';
+        $this->title = 'Usu&aacute;rios';
         $this->processoAp = '555';
     }
 };

--- a/ieducar/intranet/include/clsBase.inc.php
+++ b/ieducar/intranet/include/clsBase.inc.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\View;
 
 class clsBase
 {
-    public $titulo = 'Prefeitura Municipal';
+
     public $clsForm = [];
     public $processoAp;
     public $renderMenu = true;
@@ -126,7 +126,7 @@ class clsBase
         }
 
         View::share('menu', $menu);
-        View::share('title', $this->titulo);
+        View::share('title', $this->getPageTitle());
 
         if ($this->renderMenu) {
             $saida_geral .= $this->MakeBody();
@@ -144,5 +144,27 @@ class clsBase
         }
 
         echo view($view, ['body' => $saida_geral])->render();
+    }
+
+    /**
+     * @return string
+     */
+    private function getPageTitle()
+    {
+        if (isset($this->title)) {
+            return $this->title;
+        }
+
+        if (isset($this->_title)) {
+            return $this->_title;
+        }
+
+        if (isset($this->titulo)) {
+            return $this->titulo;
+        }
+
+        if (isset($this->_titulo)) {
+            return $this->_titulo;
+        }
     }
 }

--- a/ieducar/intranet/include/clsCadastro.inc.php
+++ b/ieducar/intranet/include/clsCadastro.inc.php
@@ -657,6 +657,10 @@ class clsCadastro extends clsCampos
             return $this->title;
         }
 
+        if (isset($this->_title)) {
+            return $this->_title;
+        }
+
         if (isset($this->titulo)) {
             return $this->titulo;
         }
@@ -664,8 +668,6 @@ class clsCadastro extends clsCampos
         if (isset($this->_titulo)) {
             return $this->_titulo;
         }
-
-        return '';
     }
 
     public function __set($name, $value)

--- a/ieducar/intranet/include/clsDetalhe.inc.php
+++ b/ieducar/intranet/include/clsDetalhe.inc.php
@@ -32,6 +32,25 @@ class clsDetalhe extends Core_Controller_Page_Abstract
         return false;
     }
 
+    private function getPageTitle()
+    {
+        if (isset($this->title)) {
+            return $this->title;
+        }
+
+        if (isset($this->_title)) {
+            return $this->_title;
+        }
+
+        if (isset($this->titulo)) {
+            return $this->titulo;
+        }
+
+        if (isset($this->_titulo)) {
+            return $this->_titulo;
+        }
+    }
+
     public function RenderHTML()
     {
         ob_start();
@@ -51,7 +70,7 @@ class clsDetalhe extends Core_Controller_Page_Abstract
             app(Breadcrumb::class)->setLegacy($this->locale);
         }
 
-        View::share('title', $this->titulo);
+        View::share('title', $this->getPageTitle());
 
         $retorno .= "
       <!-- detalhe begin -->

--- a/ieducar/intranet/include/clsListagem.inc.php
+++ b/ieducar/intranet/include/clsListagem.inc.php
@@ -200,9 +200,28 @@ HTML;
         }
     }
 
+    private function getPageTitle()
+    {
+        if (isset($this->title)) {
+            return $this->title;
+        }
+
+        if (isset($this->_title)) {
+            return $this->_title;
+        }
+
+        if (isset($this->titulo)) {
+            return $this->titulo;
+        }
+
+        if (isset($this->_titulo)) {
+            return $this->_titulo;
+        }
+    }
+
     public function RenderHTML()
     {
-        View::share('title', $this->titulo);
+        View::share('title', $this->getPageTitle());
 
         ob_start();
 

--- a/resources/views/layout/base.blade.php
+++ b/resources/views/layout/base.blade.php
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="{{ url('favicon.ico') }}" />
-    <title>{{ config('legacy.app.name') }} @if(isset($title)) - {!! $title !!} @endif</title>
+    <title>@if(isset($title)) {!! $title !!} - @endif {{ config('legacy.app.entity.name') }} - i-Educar</title>
+    
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans">
     <link rel="stylesheet" href="{{ Asset::get('css/vue-multiselect.min.css') }}">
     <link rel="stylesheet" href="{{ Asset::get('intranet/styles/font-awesome.css') }}">
@@ -17,7 +18,7 @@
 <div class="ieducar-container">
     <header class="ieducar-header">
         <div class="ieducar-header-logo">
-            <h1><a href="{{ url('/') }}">{{ config('legacy.app.name') }}</a></h1>
+            <h1><a href="{{ url('/') }}">i-Educar</a></h1>
         </div>
         <div class="ieducar-header-links">
             <div class="dropdown">

--- a/resources/views/layout/blank.blade.php
+++ b/resources/views/layout/blank.blade.php
@@ -5,7 +5,7 @@
     <meta http-equiv="Pragma" content="no-cache"/>
     <meta http-equiv="Expires" content="-1"/>
     <link rel="shortcut icon" href="{{ url('favicon.ico') }}" />
-    <title>{{ config('legacy.app.name') }} @if(isset($title)) - {{$title}} @endif</title>
+    <title>@if(isset($title)) {!! $title !!} - @endif {{ config('legacy.app.entity.name') }} - i-Educar</title>
 
     <script>
         dataLayer = [{

--- a/resources/views/layout/default.blade.php
+++ b/resources/views/layout/default.blade.php
@@ -5,10 +5,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="-1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-
     <link rel="shortcut icon" href="{{ url('favicon.ico') }}" />
-
-    <title>{{ config('legacy.app.name') }} @if(isset($title)) - {!! $title !!} @endif</title>
+    <title>@if(isset($title)) {!! $title !!} - @endif {{ config('legacy.app.entity.name') }} - i-Educar</title>
 
     <script>
         dataLayer = [{
@@ -165,7 +163,7 @@
         <td colspan="2">
             <header class="ieducar-header">
                 <div class="ieducar-header-logo">
-                    <h1><a href="{{ url('/') }}">{{ config('legacy.app.name') }}</a></h1>
+                    <h1><a href="{{ url('/') }}">i-Educar</a></h1>
                 </div>
                 <div class="ieducar-header-links">
                     <div class="dropdown">

--- a/resources/views/layout/public.blade.php
+++ b/resources/views/layout/public.blade.php
@@ -2,9 +2,8 @@
 <html lang="pt-br">
 <head>
     <meta charset="utf-8"/>
-    <title>{{ config('legacy.app.name') }}</title>
-
     <link rel="shortcut icon" href="{{ url('favicon.ico') }}" />
+    <title>@if(isset($title)) {!! $title !!} - @endif {{ config('legacy.app.entity.name') }} - i-Educar</title>
 
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans">
     <link rel="stylesheet" type="text/css" href="{{ url('intranet/styles/login.css') }}">


### PR DESCRIPTION
Atendendo solicitação do @edersoares realizada no [PR-809](https://github.com/portabilis/i-educar/pull/809)

Em resumo, fixando o brand i-Educar no title como também na tag h1 da header, como também padronizando a ordem do titulo das guias.