### PR TITLE
Fallback para a rota `web`

### DIFF
--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -33,4 +33,13 @@ class WebController extends Controller
             'logo' => config('legacy.report.logo_file_name')
         ];
     }
+
+    public function fallback($uri)
+    {
+        if (str_starts_with($uri, 'web')) {
+            return redirect('intranet/educar_index.php');
+        }
+
+        return abort(404);
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -167,4 +167,6 @@ Route::group(['middleware' => ['ieducar.navigation', 'ieducar.footer', 'ieducar.
         ->name('schoolclass.store');
     Route::delete('/turma', [SchoolClassController::class, 'delete'])
         ->name('schoolclass.delete');
+
+    Route::fallback([WebController::class, 'fallback']);
 });


### PR DESCRIPTION
Como no PR https://github.com/portabilis/i-educar/pull/869 adiciona fallback para a rota `web` até o pacote UI estar disponível na comunidade.