### PR TITLE
Exibindo o campo ano no formulário de rematrícula automática

### DIFF
--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/RematriculaAutomatica.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/RematriculaAutomatica.js
@@ -1,7 +1,7 @@
 
 $j(document).ready(function(){
 
-  $j('#ano').closest('tr').hide();
+  $j('#ano').closest('tr').show();
 
   var $escolaField = getElementFor('escola');
 


### PR DESCRIPTION
**DESCRIÇÃO:**

Exibindo o campo ano letivo no formulário de rematrícula automática. Com este campo escondido estava impedindo a realização desta operação de rematrícula.

**AMBIENTE:**

- Plataforma utilizada: instalação direta
- Sistema operacional e versão: Ubuntu 18.04
- Navegador e versão: Firefox 120.0.1 (64-bits)

