### PR TITLE
Implementa opções de boletins do professor através do contrato

### DIFF
--- a/app/Console/Commands/LegacyCreateTestsCommand.php
+++ b/app/Console/Commands/LegacyCreateTestsCommand.php
@@ -210,6 +210,7 @@ class LegacyCreateTestsCommand extends Command
             'migra_alunos.php',
             'index.php',
             'copia_vinculos_servidores_cad.php',
+            'educar_configuracoes_gerais.php',
         ];
     }
 

--- a/ieducar/intranet/educar_configuracoes_gerais.php
+++ b/ieducar/intranet/educar_configuracoes_gerais.php
@@ -1,5 +1,6 @@
 <?php
 
+use iEducar\Reports\Contracts\TeacherReportCard;
 use Illuminate\Support\Facades\Cache;
 
 return new class extends clsCadastro
@@ -173,16 +174,13 @@ return new class extends clsCadastro
             'value' => $this->tamanho_min_rede_estadual,
         ]);
 
+        $teacherReporcCard = app(TeacherReportCard::class);
         $options = [
             'label' => 'Modelo do boletim do professor',
-            'resources' => [
-                1 => _cl(key: 'report.boletim_professor.modelo_padrao'),
-                2 => _cl(key: 'report.boletim_professor.modelo_recuperacao_por_etapa'),
-                3 => _cl(key: 'report.boletim_professor.modelo_recuperacao_paralela'),
-                4 => _cl(key: 'report.boletim_professor.modelo_html'),
-            ],
+            'resources' => $teacherReporcCard->getOptions(),
             'value' => $this->modelo_boletim_professor,
         ];
+
         $this->inputsHelper()->select(attrName: 'modelo_boletim_professor', inputOptions: $options);
 
         $this->inputsHelper()->text(attrNames: 'url_cadastro_usuario', inputOptions: [

--- a/src/Reports/Contracts/TeacherReportCard.php
+++ b/src/Reports/Contracts/TeacherReportCard.php
@@ -4,4 +4,5 @@ namespace iEducar\Reports\Contracts;
 
 interface TeacherReportCard
 {
+    public function getOptions(): array;
 }


### PR DESCRIPTION
**DESCRIÇÃO:**
Para facilitar a refatoração, diminuir o número de tags fixas no código do i-Educar foi adicionado o retorno das opções do Boletim do Professor através de um bind com o pacote de relatórios conforme o PR https://github.com/portabilis/i-educar-reports-package/pull/150