### PR TITLE
Ativa extensões do PHP

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -45,7 +45,18 @@ RUN docker-php-ext-install  \
     pdo \
     pdo_pgsql \
     pgsql \
-    zip
+    zip \
+    ftp
+
+RUN docker-php-ext-enable  \
+     bcmath \
+     gd \
+     pcntl \
+     pdo \
+     pdo_pgsql \
+     pgsql \
+     zip \
+     ftp
 
 # https://github.com/docker-library/php/issues/436#issuecomment-303171390
 RUN apk del .phpize_deps


### PR DESCRIPTION
Close https://github.com/portabilis/i-educar/issues/939.

Foi identificado pelo @flustosa que estavam faltando extensões na imagem Docker do container PHP.

Utiliza a solução proposta na issue https://github.com/portabilis/i-educar/issues/939.