### PR TITLE
Fix: comando para executar o seed do banco de dados

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,7 +49,7 @@ Execute o comando para fazer uma nova instalação:
 
 ```bash
 docker-compose exec php composer new-install
-docker-compose exec php artisan db:seed
+docker-compose exec php php artisan db:seed
 ```
 
 ### Personalizando a instalação


### PR DESCRIPTION

Corrigido o comando para executar o seeding do banco de dados, ajustando o nome correto do serviço no Docker Compose ([docker-compose exec php php artisan db:seed] ao invés de [docker-compose exec php artisan db:seed]), pois o comando recomendado esta lançando um "': No such file or directory"

- Plataforma utilizada: Docker
- Sistema operacional e versão: Windows 10
- Navegador e versão: Edge 130.0.2849.68
- O comando anterior estava lançando um "': No such file or directory", mas após mudar apara o novo, que adiciona mais um parâmetro "php" ao comando, a seeding foi executada com sucesso.
