### PR TITLE
Corrige formatação de CPF na função `formata_cpf(numeric)`

### DIFF
--- a/database/migrations/legacy/2025_01_01_130000_modify_function_public_formata_cpf.php
+++ b/database/migrations/legacy/2025_01_01_130000_modify_function_public_formata_cpf.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddFunctionPublicFormataCpf extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::unprepared(
+            file_get_contents(__DIR__ . '/../../sqls/functions/public.formata_cpf.sql')
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::unprepared(
+            'DROP FUNCTION public.formata_cpf(cpf numeric);'
+        );
+    }
+}

--- a/database/migrations/legacy/2025_01_01_130000_modify_function_public_formata_cpf.php
+++ b/database/migrations/legacy/2025_01_01_130000_modify_function_public_formata_cpf.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
-class AddFunctionPublicFormataCpf extends Migration
+class ModifyFunctionPublicFormataCpf extends Migration
 {
     /**
      * Run the migrations.

--- a/database/sqls/functions/public.formata_cpf.sql
+++ b/database/sqls/functions/public.formata_cpf.sql
@@ -1,13 +1,23 @@
-CREATE OR REPLACE FUNCTION public.formata_cpf(cpf numeric) RETURNS character varying
-    LANGUAGE plpgsql
-    AS $$
+CREATE OR REPLACE FUNCTION public.formata_cpf(cpf numeric)
+RETURNS character varying
+LANGUAGE plpgsql
+AS $function$
 DECLARE
-	cpf_formatado varchar(11) := '';
+    cpf_text text;
+    cpf_formatado varchar(14);
 BEGIN
-  cpf_formatado := (SUBSTR(TO_CHAR(cpf, '00000000000'), 1, 4) || '.' ||
-		    		SUBSTR(TO_CHAR(cpf, '00000000000'), 5, 3) || '.' ||
-		    		SUBSTR(TO_CHAR(cpf, '00000000000'), 8, 3) || '-' ||
-		    		SUBSTR(TO_CHAR(cpf, '00000000000'), 11, 2)) ;
+  IF cpf IS NULL THEN
+    RETURN '';
+  END IF;
+
+  -- Converte o CPF numérico para texto e preenche com zeros à esquerda
+  cpf_text := lpad(TRIM(TO_CHAR(cpf, 'FM99999999999')), 11, '0');
+
+  cpf_formatado := SUBSTR(cpf_text, 1, 3) || '.' ||
+                   SUBSTR(cpf_text, 4, 3) || '.' ||
+                   SUBSTR(cpf_text, 7, 3) || '-' ||
+                   SUBSTR(cpf_text, 10, 2);
+
   RETURN cpf_formatado;
 END;
-$$;
+$function$;


### PR DESCRIPTION
**DESCRIÇÃO:**

Corrige formatação de CPF na função `formata_cpf(numeric)` para garantir consistência com zeros à esquerda

Ajusta a função `formata_cpf(numeric)` para:
- Garantir que o CPF tenha exatamente 11 dígitos com zeros à esquerda usando `LPAD`
- Corrigir o tamanho da variável `cpf_formatado` para `varchar(14)` (comportando `000.000.000-00`)
- Corrigir os índices de `SUBSTR`, evitando erro na formatação
- Melhorar legibilidade e eficiência ao evitar múltiplas chamadas a `TO_CHAR`

Essa correção evita resultados inconsistentes, especialmente quando o valor do CPF contém zeros à esquerda.


📌 Versão atual:
```
cpf_formatado := (SUBSTR(TO_CHAR(cpf, '00000000000'), 1, 4) || '.' ||
                  SUBSTR(TO_CHAR(cpf, '00000000000'), 5, 3) || '.' ||
                  SUBSTR(TO_CHAR(cpf, '00000000000'), 8, 3) || '-' ||
                  SUBSTR(TO_CHAR(cpf, '00000000000'), 11, 2));
```
**Problemas dessa abordagem:**

- varchar(11), não comporta 14 caracteres (000.000.000-00)
- Usa SUBSTR(..., 1, 4), está pegando quatro dígitos no início, ao invés de três.
- Repete várias vezes TO_CHAR(cpf, '00000000000').
- Pode falhar quando cpf tem menos de 11 dígitos reais (ex: 01234567890) porque numeric perde zeros à esquerda.

    
✅ Versão proposta:
```
cpf_text := lpad(TRIM(TO_CHAR(cpf, 'FM99999999999')), 11, '0');

cpf_formatado := SUBSTR(cpf_text, 1, 3) || '.' ||
                 SUBSTR(cpf_text, 4, 3) || '.' ||
                 SUBSTR(cpf_text, 7, 3) || '-' ||
                 SUBSTR(cpf_text, 10, 2);
```
**Vantagens:**

- Usa varchar(14), que comporta o formato 000.000.000-00
- Usa SUBSTR(..., 1, 3) corretamente
- Usa LPAD(..., 11, '0') para garantir 11 dígitos com zeros à esquerda
- Não repete TO_CHAR 4 vezes