### PR TITLE
Suporte a logos remotos por URL na geração de relatórios PHPJasper

### DIFF
--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -36,12 +36,28 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
      */
     public function logoPath()
     {
-        if (!$this->settings['logo_file_name']) {
+        $logo = $this->settings['logo_file_name'];
+
+        if (!$logo) {
             throw new Exception('No report.logo_file_name defined in configurations!');
         }
 
+        if (filter_var($logo, FILTER_VALIDATE_URL)) {
+            $tmpFile = sys_get_temp_dir() . '/logo_' . md5($logo) . '.png';
+
+            if (!file_exists($tmpFile)) {
+                $imageData = file_get_contents($logo);
+                if ($imageData === false) {
+                    throw new Exception("Erro ao baixar logo da URL: $logo");
+                }
+                file_put_contents($tmpFile, $imageData);
+            }
+
+            return $tmpFile;
+        }
+
         $rootPath = dirname(dirname(dirname(dirname(__FILE__))));
-        $filePath = $rootPath . "/modules/Reports/ReportLogos/{$this->settings['logo_file_name']}";
+        $filePath = $rootPath . "/modules/Reports/ReportLogos/{$logo}";
 
         if (!file_exists($filePath)) {
             throw new CoreExt_Exception("Report logo '{$this->settings['logo_file_name']}' not found in path '$filePath'");

--- a/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
+++ b/ieducar/lib/Portabilis/Report/ReportFactoryPHPJasper.php
@@ -43,7 +43,7 @@ class Portabilis_Report_ReportFactoryPHPJasper extends Portabilis_Report_ReportF
         }
 
         if (filter_var($logo, FILTER_VALIDATE_URL)) {
-            $tmpFile = sys_get_temp_dir() . '/logo_' . md5($logo) . '.png';
+            $tmpFile = sys_get_temp_dir() . '/logo_' . hash('sha256', $logo) . '.png';
 
             if (!file_exists($tmpFile)) {
                 $imageData = file_get_contents($logo);


### PR DESCRIPTION
## Descrição

Este PR ajusta a lógica da fábrica de relatórios `PHPJasper` para permitir que o campo `logo_file_name` aponte para uma URL, além de um arquivo local.

## Alterações realizadas

- Verifica se `logo_file_name` é uma URL válida.
- Caso seja, faz download da imagem para diretório temporário e usa o caminho local como logo.
- Caso contrário, mantém a lógica anterior de buscar por arquivos locais.

## Objetivo

Permitir maior flexibilidade na configuração dos relatórios, suportando logos remotos via URL, sem quebrar a compatibilidade com os caminhos locais.

## Observações

- A imagem da URL é salva temporariamente com hash MD5 do endereço.
- Caso o download falhe, uma exceção é lançada.

