### PR TITLE
Ajusta valor conforme novo layout do Educacenso

### DIFF
--- a/src/Modules/Educacenso/ExportRule/RecebeEscolarizacaoOutroEspaco.php
+++ b/src/Modules/Educacenso/ExportRule/RecebeEscolarizacaoOutroEspaco.php
@@ -21,7 +21,7 @@ class RecebeEscolarizacaoOutroEspaco implements EducacensoExportRule
                 $registro60->localFuncionamentoDiferenciadoTurma != \App_Model_LocalFuncionamentoDiferenciado::SALA_ANEXA
             )
         ) {
-            $registro60->recebeEscolarizacaoOutroEspacao = null;
+            $registro60->recebeEscolarizacaoOutroEspacao = 1;
         }
 
         return $registro60;


### PR DESCRIPTION
Insere o valor conforme layout do censo escolar.


**DESCRIÇÃO:**

Ao tentar importar arquivo.txt para o Educacenso recebi um aviso de recusa por causa do registro 60, campo 20 estava null onde deveria está com valor 1.

**AMBIENTE:**

Docker
