### PR TITLE
Ajusta campo para não ficar vazio.

### DIFF
--- a/src/Modules/Educacenso/ExportRule/RecebeEscolarizacaoOutroEspaco.php
+++ b/src/Modules/Educacenso/ExportRule/RecebeEscolarizacaoOutroEspaco.php
@@ -21,7 +21,7 @@ class RecebeEscolarizacaoOutroEspaco implements EducacensoExportRule
                 $registro60->localFuncionamentoDiferenciadoTurma != \App_Model_LocalFuncionamentoDiferenciado::SALA_ANEXA
             )
         ) {
-            $registro60->recebeEscolarizacaoOutroEspacao = null;
+            $registro60->recebeEscolarizacaoOutroEspacao;
         }
 
         return $registro60;


### PR DESCRIPTION
**DESCRIÇÃO:**

Com a exigência de preenchimento do campo pelo layout do Educancenso, se fez necessário essa mudança para não vir o campo null.

**AMBIENTE:**

- Plataforma utilizada (Docker)
