### PR TITLE
Ajusta para campo não ficar null.

### DIFF
--- a/src/Modules/Educacenso/ExportRule/TransporteEscolarPublico.php
+++ b/src/Modules/Educacenso/ExportRule/TransporteEscolarPublico.php
@@ -23,7 +23,7 @@ class TransporteEscolarPublico implements EducacensoExportRule
         if ($registro60->tipoAtendimentoTurma != TipoAtendimentoTurma::CURRICULAR_ETAPA_ENSINO ||
             !in_array($registro60->tipoMediacaoTurma, $arrayTipoMediacao) ||
             $registro60->paisResidenciaAluno != PaisResidencia::BRASIL) {
-            $registro60->transportePublico = null;
+            $registro60->transportePublico;
         }
 
         return $registro60;


### PR DESCRIPTION

**DESCRIÇÃO:**

O campo não pode ficar null, de acordo com layout do Educacenso.

**AMBIENTE:**

- Plataforma utilizada (Docker)
