### PR TITLE
fix: adiciona validação de carga horária no cadastro de servidor (#1063)

### DIFF
--- a/ieducar/intranet/educar_servidor_alocacao_cad.php
+++ b/ieducar/intranet/educar_servidor_alocacao_cad.php
@@ -246,6 +246,13 @@ return new class extends clsCadastro
 
     public function Novo()
     {
+        // Valida a carga horária alocada antes de processar
+        $validacao = $this->validaCargaHoraria($this->carga_horaria_alocada);
+        if (!$validacao['valido']) {
+            $this->mensagem = $validacao['mensagem'];
+            return false;
+        }
+
         $obj_permissoes = new clsPermissoes;
         $obj_permissoes->permissao_cadastra(
             635,
@@ -375,6 +382,64 @@ return new class extends clsCadastro
         }
 
         return $total;
+    }
+
+    /**
+     * Valida o formato da carga horária
+     * @param string $cargaHoraria
+     * @return array
+     */
+    protected function validaCargaHoraria($cargaHoraria)
+    {
+        if (empty($cargaHoraria)) {
+            return [
+                'valido' => true,
+                'mensagem' => ''
+            ];
+        }
+
+        // Remove espaços em branco
+        $cargaHoraria = trim($cargaHoraria);
+
+        // Verifica se está no formato HH:MM
+        if (!preg_match('/^([0-2]?[0-9]):([0-5][0-9])$/', $cargaHoraria, $matches)) {
+            return [
+                'valido' => false,
+                'mensagem' => 'Carga horária inválida. Informe um valor no formato HH:MM.'
+            ];
+        }
+
+        $horas = (int) $matches[1];
+        $minutos = (int) $matches[2];
+
+        // Verifica se as horas são válidas (0-24)
+        if ($horas > 24) {
+            return [
+                'valido' => false,
+                'mensagem' => 'Carga horária inválida. As horas não podem ser maiores que 24.'
+            ];
+        }
+
+        // Verifica se os minutos são válidos (0-59)
+        if ($minutos > 59) {
+            return [
+                'valido' => false,
+                'mensagem' => 'Carga horária inválida. Os minutos não podem ser maiores que 59.'
+            ];
+        }
+
+        // Verifica se não é 24:XX com minutos > 00
+        if ($horas === 24 && $minutos > 0) {
+            return [
+                'valido' => false,
+                'mensagem' => 'Carga horária inválida. Se as horas forem 24, os minutos devem ser 00.'
+            ];
+        }
+
+        return [
+            'valido' => true,
+            'mensagem' => ''
+        ];
     }
 
     public function Formular()

--- a/ieducar/intranet/educar_servidor_alocacao_cad.php
+++ b/ieducar/intranet/educar_servidor_alocacao_cad.php
@@ -247,9 +247,7 @@ return new class extends clsCadastro
     public function Novo()
     {
         // Valida a carga horária alocada antes de processar
-        $validacao = $this->validaCargaHoraria($this->carga_horaria_alocada);
-        if (!$validacao['valido']) {
-            $this->mensagem = $validacao['mensagem'];
+        if ($this->notValidaCargaHoraria($this->carga_horaria_alocada)) {
             return false;
         }
 
@@ -385,61 +383,34 @@ return new class extends clsCadastro
     }
 
     /**
-     * Valida o formato da carga horária
+     * Valida o formato da carga horária usando Validator
      * @param string $cargaHoraria
-     * @return array
+     * @return bool
      */
-    protected function validaCargaHoraria($cargaHoraria)
+    protected function notValidaCargaHoraria($cargaHoraria)
     {
         if (empty($cargaHoraria)) {
-            return [
-                'valido' => true,
-                'mensagem' => ''
-            ];
+            return false;
         }
 
-        // Remove espaços em branco
-        $cargaHoraria = trim($cargaHoraria);
+        $validator = Validator::make([
+            'carga_horaria' => $cargaHoraria,
+        ], [
+            'carga_horaria' => [
+                'required',
+                'regex:/^(?:(?:[01]?[0-9]|2[0-3]):[0-5][0-9]|24:00)$/',
+            ],
+        ], [
+            'carga_horaria.required' => 'Carga horária é obrigatória.',
+            'carga_horaria.regex' => 'Carga horária inválida. Informe um valor no formato HH:MM (máximo 24:00).',
+        ]);
 
-        // Verifica se está no formato HH:MM
-        if (!preg_match('/^([0-2]?[0-9]):([0-5][0-9])$/', $cargaHoraria, $matches)) {
-            return [
-                'valido' => false,
-                'mensagem' => 'Carga horária inválida. Informe um valor no formato HH:MM.'
-            ];
+        if ($validator->fails()) {
+            $this->mensagem = $validator->errors()->first();
+            return true;
         }
 
-        $horas = (int) $matches[1];
-        $minutos = (int) $matches[2];
-
-        // Verifica se as horas são válidas (0-24)
-        if ($horas > 24) {
-            return [
-                'valido' => false,
-                'mensagem' => 'Carga horária inválida. As horas não podem ser maiores que 24.'
-            ];
-        }
-
-        // Verifica se os minutos são válidos (0-59)
-        if ($minutos > 59) {
-            return [
-                'valido' => false,
-                'mensagem' => 'Carga horária inválida. Os minutos não podem ser maiores que 59.'
-            ];
-        }
-
-        // Verifica se não é 24:XX com minutos > 00
-        if ($horas === 24 && $minutos > 0) {
-            return [
-                'valido' => false,
-                'mensagem' => 'Carga horária inválida. Se as horas forem 24, os minutos devem ser 00.'
-            ];
-        }
-
-        return [
-            'valido' => true,
-            'mensagem' => ''
-        ];
+        return false;
     }
 
     public function Formular()

--- a/ieducar/intranet/educar_servidor_cad.php
+++ b/ieducar/intranet/educar_servidor_cad.php
@@ -361,9 +361,9 @@ return new class extends clsCadastro
             'Carga Horária',
             $hora_formatada,
             true,
-            ' Número de horas deve ser maior que horas alocadas',
+            'Informe a carga horária no formato HH:MM (ex: 08:30, máximo 24:00)',
             '',
-            false
+            true
         );
 
         $this->inputsHelper()->checkbox('multi_seriado', ['label' => 'Multisseriado', 'value' => $this->multi_seriado]);
@@ -493,6 +493,13 @@ JS;
         $this->cod_servidor = (int) $this->cod_servidor;
         $this->ref_cod_instituicao = (int) $this->ref_cod_instituicao;
 
+        // Valida a carga horária antes de processar
+        $validacao = $this->validaCargaHoraria($this->carga_horaria);
+        if (!$validacao['valido']) {
+            $this->mensagem = $validacao['mensagem'];
+            return false;
+        }
+
         $timesep = explode(':', $this->carga_horaria);
         $hour = (int) $timesep[0] + ((int) ($timesep[1] / 60));
         $min = abs(((int) ($timesep[1] / 60)) - ($timesep[1] / 60)) . '<br>';
@@ -572,6 +579,14 @@ JS;
 
             return false;
         }
+
+        // Valida a carga horária antes de processar
+        $validacao = $this->validaCargaHoraria($this->carga_horaria);
+        if (!$validacao['valido']) {
+            $this->mensagem = $validacao['mensagem'];
+            return false;
+        }
+
         $timesep = explode(':', $this->carga_horaria);
         $hour = $timesep[0] + ((int) ($timesep[1] / 60));
         $min = abs(((int) ($timesep[1] / 60)) - ($timesep[1] / 60)) . '<br>';
@@ -1180,6 +1195,64 @@ JS;
         $college = DB::table('modules.educacenso_ies')->where('id', $collegeId)->get(['nome', 'ies_id'])->first();
 
         return $college->ies_id . ' - ' . $college->nome;
+    }
+
+    /**
+     * Valida o formato da carga horária
+     * @param string $cargaHoraria
+     * @return array
+     */
+    protected function validaCargaHoraria($cargaHoraria)
+    {
+        if (empty($cargaHoraria)) {
+            return [
+                'valido' => true,
+                'mensagem' => ''
+            ];
+        }
+
+        // Remove espaços em branco
+        $cargaHoraria = trim($cargaHoraria);
+
+        // Verifica se está no formato HH:MM
+        if (!preg_match('/^([0-2]?[0-9]):([0-5][0-9])$/', $cargaHoraria, $matches)) {
+            return [
+                'valido' => false,
+                'mensagem' => 'Carga horária inválida. Informe um valor no formato HH:MM.'
+            ];
+        }
+
+        $horas = (int) $matches[1];
+        $minutos = (int) $matches[2];
+
+        // Verifica se as horas são válidas (0-24)
+        if ($horas > 24) {
+            return [
+                'valido' => false,
+                'mensagem' => 'Carga horária inválida. As horas não podem ser maiores que 24.'
+            ];
+        }
+
+        // Verifica se os minutos são válidos (0-59)
+        if ($minutos > 59) {
+            return [
+                'valido' => false,
+                'mensagem' => 'Carga horária inválida. Os minutos não podem ser maiores que 59.'
+            ];
+        }
+
+        // Verifica se não é 24:XX com minutos > 00
+        if ($horas === 24 && $minutos > 0) {
+            return [
+                'valido' => false,
+                'mensagem' => 'Carga horária inválida. Se as horas forem 24, os minutos devem ser 00.'
+            ];
+        }
+
+        return [
+            'valido' => true,
+            'mensagem' => ''
+        ];
     }
 
     public function makeExtra()

--- a/ieducar/intranet/educar_servidor_cad.php
+++ b/ieducar/intranet/educar_servidor_cad.php
@@ -494,9 +494,7 @@ JS;
         $this->ref_cod_instituicao = (int) $this->ref_cod_instituicao;
 
         // Valida a carga horária antes de processar
-        $validacao = $this->validaCargaHoraria($this->carga_horaria);
-        if (!$validacao['valido']) {
-            $this->mensagem = $validacao['mensagem'];
+        if ($this->notValidaCargaHoraria($this->carga_horaria)) {
             return false;
         }
 
@@ -581,9 +579,7 @@ JS;
         }
 
         // Valida a carga horária antes de processar
-        $validacao = $this->validaCargaHoraria($this->carga_horaria);
-        if (!$validacao['valido']) {
-            $this->mensagem = $validacao['mensagem'];
+        if ($this->notValidaCargaHoraria($this->carga_horaria)) {
             return false;
         }
 
@@ -1198,61 +1194,34 @@ JS;
     }
 
     /**
-     * Valida o formato da carga horária
+     * Valida o formato da carga horária usando Validator
      * @param string $cargaHoraria
-     * @return array
+     * @return bool
      */
-    protected function validaCargaHoraria($cargaHoraria)
+    protected function notValidaCargaHoraria($cargaHoraria)
     {
         if (empty($cargaHoraria)) {
-            return [
-                'valido' => true,
-                'mensagem' => ''
-            ];
+            return false;
         }
 
-        // Remove espaços em branco
-        $cargaHoraria = trim($cargaHoraria);
+        $validator = Validator::make([
+            'carga_horaria' => $cargaHoraria,
+        ], [
+            'carga_horaria' => [
+                'required',
+                'regex:/^(?:(?:[01]?[0-9]|2[0-3]):[0-5][0-9]|24:00)$/',
+            ],
+        ], [
+            'carga_horaria.required' => 'Carga horária é obrigatória.',
+            'carga_horaria.regex' => 'Carga horária inválida. Informe um valor no formato HH:MM (máximo 24:00).',
+        ]);
 
-        // Verifica se está no formato HH:MM
-        if (!preg_match('/^([0-2]?[0-9]):([0-5][0-9])$/', $cargaHoraria, $matches)) {
-            return [
-                'valido' => false,
-                'mensagem' => 'Carga horária inválida. Informe um valor no formato HH:MM.'
-            ];
+        if ($validator->fails()) {
+            $this->mensagem = $validator->errors()->first();
+            return true;
         }
 
-        $horas = (int) $matches[1];
-        $minutos = (int) $matches[2];
-
-        // Verifica se as horas são válidas (0-24)
-        if ($horas > 24) {
-            return [
-                'valido' => false,
-                'mensagem' => 'Carga horária inválida. As horas não podem ser maiores que 24.'
-            ];
-        }
-
-        // Verifica se os minutos são válidos (0-59)
-        if ($minutos > 59) {
-            return [
-                'valido' => false,
-                'mensagem' => 'Carga horária inválida. Os minutos não podem ser maiores que 59.'
-            ];
-        }
-
-        // Verifica se não é 24:XX com minutos > 00
-        if ($horas === 24 && $minutos > 0) {
-            return [
-                'valido' => false,
-                'mensagem' => 'Carga horária inválida. Se as horas forem 24, os minutos devem ser 00.'
-            ];
-        }
-
-        return [
-            'valido' => true,
-            'mensagem' => ''
-        ];
+        return false;
     }
 
     public function makeExtra()

--- a/ieducar/intranet/include/clsCampos.inc.php
+++ b/ieducar/intranet/include/clsCampos.inc.php
@@ -359,10 +359,13 @@ class clsCampos extends Core_Controller_Page_Abstract
 
     public function campoHora($nome, $campo, $valor, $obrigatorio = false, $descricao = '', $acao = '', $limitaHora = true, $desabilitado = false, $maxLength = 5)
     {
+        // Expressão regular que permite de 00:00 até 24:00 (24:00 apenas com minutos 00)
+        $regexHora = $limitaHora ? '/^(([0-1]?[0-9]|2[0-3]):([0-5][0-9])|24:00)(:[0-5][0-9])?$/' : '/[0-9]{2}:[0-9]{2}/';
+        
         $arr_componente = [
             'hora',
             $this->__adicionando_tabela ? $nome : $campo,
-            $limitaHora ? ($obrigatorio ? '/^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])?$/' : '*(/^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])?$/)') : ($obrigatorio ? '/[0-9]{2}:[0-9]{2}/' : '*(/[0-9]{2}:[0-9]{2}/)'),
+            $obrigatorio ? $regexHora : '*(' . $regexHora . ')',
             $valor,
             6,
             $maxLength,
@@ -381,10 +384,13 @@ class clsCampos extends Core_Controller_Page_Abstract
 
     public function campoHoraServidor($nome, $campo, $valor, $obrigatorio = false, $descricao = '', $acao = '', $limitaHora = true)
     {
+        // Expressão regular que permite de 00:00 até 24:00 para servidor (24:00 apenas com minutos 00)
+        $regexHora = $limitaHora ? '/^(([0-1]?[0-9]|2[0-3]):([0-5][0-9])|24:00)(:[0-5][0-9])?$/' : '/[0-9]{2}:[0-9]{2}/';
+        
         $arr_componente = [
             'hora',
             $this->__adicionando_tabela ? $nome : $campo,
-            $limitaHora ? ($obrigatorio ? '/^([0-9]?[0-9]|9[0-9]):([0-5][0-9])(:[0-5][0-9])?$/' : '*(/^([0-9]?[0-9]|9[0-9]):([0-5][0-9])(:[0-5][0-9])?$/)') : ($obrigatorio ? '/[0-9]{2}:[0-9]{2}/' : '*(/[0-9]{9}:[0-9]{2}/)'),
+            $obrigatorio ? $regexHora : '*(' . $regexHora . ')',
             $valor,
             6,
             5,

--- a/ieducar/intranet/include/clsCampos.inc.php
+++ b/ieducar/intranet/include/clsCampos.inc.php
@@ -360,8 +360,8 @@ class clsCampos extends Core_Controller_Page_Abstract
     public function campoHora($nome, $campo, $valor, $obrigatorio = false, $descricao = '', $acao = '', $limitaHora = true, $desabilitado = false, $maxLength = 5)
     {
         // Expressão regular que permite de 00:00 até 24:00 (24:00 apenas com minutos 00)
-        $regexHora = $limitaHora ? '/^(([0-1]?[0-9]|2[0-3]):([0-5][0-9])|24:00)(:[0-5][0-9])?$/' : '/[0-9]{2}:[0-9]{2}/';
-        
+        $regexHora = $limitaHora ? '/^(?:(?:[01]?[0-9]|2[0-3]):[0-5][0-9]|24:00)$/' : '/[0-9]{2}:[0-9]{2}/';
+
         $arr_componente = [
             'hora',
             $this->__adicionando_tabela ? $nome : $campo,
@@ -385,8 +385,8 @@ class clsCampos extends Core_Controller_Page_Abstract
     public function campoHoraServidor($nome, $campo, $valor, $obrigatorio = false, $descricao = '', $acao = '', $limitaHora = true)
     {
         // Expressão regular que permite de 00:00 até 24:00 para servidor (24:00 apenas com minutos 00)
-        $regexHora = $limitaHora ? '/^(([0-1]?[0-9]|2[0-3]):([0-5][0-9])|24:00)(:[0-5][0-9])?$/' : '/[0-9]{2}:[0-9]{2}/';
-        
+        $regexHora = $limitaHora ? '/^(?:(?:[01]?[0-9]|2[0-3]):[0-5][0-9]|24:00)$/' : '/[0-9]{2}:[0-9]{2}/';
+
         $arr_componente = [
             'hora',
             $this->__adicionando_tabela ? $nome : $campo,

--- a/ieducar/intranet/scripts/extra/educar-servidor-cad.js
+++ b/ieducar/intranet/scripts/extra/educar-servidor-cad.js
@@ -132,9 +132,75 @@ function getArrayHora(hora) {
   return array_h;
 }
 
+/**
+ * Valida o formato de carga horária HH:MM
+ */
+function validaCargaHoraria(cargaHoraria) {
+  // Remove espaços e verifica se está no formato correto
+  var valor = cargaHoraria.trim();
+  
+  // Verifica se está no formato HH:MM
+  var regex = /^([0-2]?[0-9]):([0-5][0-9])$/;
+  var match = valor.match(regex);
+  
+  if (!match) {
+    return {
+      valido: false,
+      mensagem: 'Carga horária inválida. Informe um valor no formato HH:MM.'
+    };
+  }
+  
+  var horas = parseInt(match[1], 10);
+  var minutos = parseInt(match[2], 10);
+  
+  // Verifica se as horas são válidas (0-24)
+  if (horas > 24) {
+    return {
+      valido: false,
+      mensagem: 'Carga horária inválida. As horas não podem ser maiores que 24.'
+    };
+  }
+  
+  // Verifica se os minutos são válidos (0-59)
+  if (minutos > 59) {
+    return {
+      valido: false,
+      mensagem: 'Carga horária inválida. Os minutos não podem ser maiores que 59.'
+    };
+  }
+  
+  // Verifica se não é 24:XX com minutos > 00
+  if (horas === 24 && minutos > 0) {
+    return {
+      valido: false,
+      mensagem: 'Carga horária inválida. Se as horas forem 24, os minutos devem ser 00.'
+    };
+  }
+  
+  return {
+    valido: true,
+    mensagem: ''
+  };
+}
+
 function acao2() {
+  var campoCargaHoraria = document.getElementById('carga_horaria');
+  var cargaHorariaValor = campoCargaHoraria ? campoCargaHoraria.value : '';
+  
+  // Valida a carga horária primeiro
+  if (cargaHorariaValor) {
+    var validacao = validaCargaHoraria(cargaHorariaValor);
+    if (!validacao.valido) {
+      alert(validacao.mensagem);
+      if (campoCargaHoraria) {
+        campoCargaHoraria.focus();
+      }
+      return false;
+    }
+  }
+  
   var total_horas_alocadas = getArrayHora(document.getElementById('total_horas_alocadas').value);
-  var carga_horaria = (document.getElementById('carga_horaria').value).replace(',', '.');
+  var carga_horaria = cargaHorariaValor.replace(',', '.');
 
   if (parseFloat(total_horas_alocadas) > parseFloat(carga_horaria)) {
     alert('Atenção, carga horária deve ser maior que horas alocadas!');
@@ -312,4 +378,16 @@ $j(document).ready(function () {
 
   $j('#cod_servidor').attr('onchange', 'atualizaInformacoesServidor();');
   $j('#cod_servidor').attr('onchange', 'verificaExistenciaDoServidor();');
+  
+  // Adiciona validação em tempo real para carga horária
+  $j('#carga_horaria').on('blur', function() {
+    var valor = $j(this).val();
+    if (valor) {
+      var validacao = validaCargaHoraria(valor);
+      if (!validacao.valido) {
+        alert(validacao.mensagem);
+        $j(this).focus();
+      }
+    }
+  });
 });

--- a/ieducar/intranet/scripts/extra/educar-servidor-cad.js
+++ b/ieducar/intranet/scripts/extra/educar-servidor-cad.js
@@ -133,50 +133,21 @@ function getArrayHora(hora) {
 }
 
 /**
- * Valida o formato de carga horária HH:MM
+ * Valida o formato de carga horária HH:MM usando regex simples
  */
 function validaCargaHoraria(cargaHoraria) {
-  // Remove espaços e verifica se está no formato correto
   var valor = cargaHoraria.trim();
-  
-  // Verifica se está no formato HH:MM
-  var regex = /^([0-2]?[0-9]):([0-5][0-9])$/;
-  var match = valor.match(regex);
-  
-  if (!match) {
+
+  // Regex que permite 00:00 até 23:59 e 24:00
+  var regex = /^(?:(?:[01]?[0-9]|2[0-3]):[0-5][0-9]|24:00)$/;
+
+  if (!regex.test(valor)) {
     return {
       valido: false,
-      mensagem: 'Carga horária inválida. Informe um valor no formato HH:MM.'
+      mensagem: 'Carga horária inválida. Informe um valor no formato HH:MM (máximo 24:00).'
     };
   }
-  
-  var horas = parseInt(match[1], 10);
-  var minutos = parseInt(match[2], 10);
-  
-  // Verifica se as horas são válidas (0-24)
-  if (horas > 24) {
-    return {
-      valido: false,
-      mensagem: 'Carga horária inválida. As horas não podem ser maiores que 24.'
-    };
-  }
-  
-  // Verifica se os minutos são válidos (0-59)
-  if (minutos > 59) {
-    return {
-      valido: false,
-      mensagem: 'Carga horária inválida. Os minutos não podem ser maiores que 59.'
-    };
-  }
-  
-  // Verifica se não é 24:XX com minutos > 00
-  if (horas === 24 && minutos > 0) {
-    return {
-      valido: false,
-      mensagem: 'Carga horária inválida. Se as horas forem 24, os minutos devem ser 00.'
-    };
-  }
-  
+
   return {
     valido: true,
     mensagem: ''
@@ -186,7 +157,7 @@ function validaCargaHoraria(cargaHoraria) {
 function acao2() {
   var campoCargaHoraria = document.getElementById('carga_horaria');
   var cargaHorariaValor = campoCargaHoraria ? campoCargaHoraria.value : '';
-  
+
   // Valida a carga horária primeiro
   if (cargaHorariaValor) {
     var validacao = validaCargaHoraria(cargaHorariaValor);
@@ -198,7 +169,7 @@ function acao2() {
       return false;
     }
   }
-  
+
   var total_horas_alocadas = getArrayHora(document.getElementById('total_horas_alocadas').value);
   var carga_horaria = cargaHorariaValor.replace(',', '.');
 
@@ -378,7 +349,7 @@ $j(document).ready(function () {
 
   $j('#cod_servidor').attr('onchange', 'atualizaInformacoesServidor();');
   $j('#cod_servidor').attr('onchange', 'verificaExistenciaDoServidor();');
-  
+
   // Adiciona validação em tempo real para carga horária
   $j('#carga_horaria').on('blur', function() {
     var valor = $j(this).val();


### PR DESCRIPTION
**DESCRIÇÃO:**

Este pull request implementa validação completa para o campo "Carga Horária" no cadastro de servidor, resolvendo o issue #1063 onde o sistema aceitava valores inválidos como 99:99, 25:00 e 12:60.

**Implementações realizadas:**

- **Validação JavaScript (Front-end):** Função `validaCargaHoraria()` que valida formato HH:MM em tempo real (onBlur) e no submit do formulário, com mensagens de erro claras
- **Validação PHP (Back-end):** Método `validaCargaHoraria()` aplicado nos métodos `Novo()` e `Editar()` dos arquivos de cadastro de servidor e alocação
- **Melhorias nas expressões regulares:** Atualização das funções `campoHora()` e `campoHoraServidor()` para permitir valores de 00:00 até 23:59 e especificamente 24:00
- **Prevenção de dados inconsistentes:** Sistema agora rejeita valores como 99:99, 25:00, 12:60, 24:30 e fornece feedback claro ao usuário

**Localização:** Menu Início → Servidores → Funções do Servidor → Novo → Campo "Carga Horária"

**Arquivos modificados:**
- ieducar/intranet/scripts/extra/educar-servidor-cad.js
- ieducar/intranet/educar_servidor_cad.php  
- ieducar/intranet/educar_servidor_alocacao_cad.php
- ieducar/intranet/include/clsCampos.inc.php

Resolve #1063

**AMBIENTE:**

- Plataforma utilizada: Docker
- Sistema operacional: Windows 11
- Navegador: Google Chrome (versão atual)
- PHP: 8.4 (conforme docker-compose.yml)
- Framework: Laravel/i-Educar