### PR TITLE
Melhora a criação de usuários/grupos no Dockerfile

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -79,8 +79,9 @@ ARG HOST_GID
 # Criação de grupo e usuário com UID e GID iguais ao do host
 # Isso garante que arquivos criados dentro do container tenham
 # as mesmas permissões do usuário do host (evita problemas com volumes)
-RUN addgroup -g ${HOST_GID} ieducar && \
-    adduser -u ${HOST_UID} -G ieducar -s /bin/sh -D ieducar
+RUN addgroup -g ${HOST_GID} ieducar 2>/dev/null || addgroup ieducar && \
+    adduser -u ${HOST_UID} -G ieducar -s /bin/sh -D ieducar 2>/dev/null || \
+    adduser -G ieducar -s /bin/sh -D ieducar
 
 # Define o usuário padrão do container para evitar execução como root
 USER ieducar


### PR DESCRIPTION
**DESCRIÇÃO:**

PR complementar ao https://github.com/portabilis/i-educar/pull/1040

O problema é que o GID 20 do macOS já está em uso dentro do container Linux para outro grupo do sistema. Sem contar que o 502 no Linux é para usuário reservado.

No Linux, o GID 20 e UID 502 geralmente pertence a um grupo/usuario, então quando o script tenta criar/modificar para usar o GID 20, ele falha.


Verifique a discução no PR https://github.com/portabilis/i-educar/pull/1040 para mais detalhes.
