### PR TITLE
Adição de teste para o método Processar() utilizado na classe clsCadastro.inc.php

### DIFF
--- a/tests/Unit/Legacy/ClsCadastroProcessarTest.php
+++ b/tests/Unit/Legacy/ClsCadastroProcessarTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use PHPUnit\Framework\Assert;
+
+class StubCadastro extends clsCadastro
+{
+    public function __construct()
+    {
+        // intentionally do not call parent constructor to avoid Laravel facades (Auth) being used
+        // but copy minimal expected state from superglobals
+        $this->tipoacao = $_POST['tipoacao'] ?? '';
+    }
+
+    public $novoReturn = false;
+    public $editarReturn = false;
+    public $excluirReturn = false;
+    public $inicializarReturn = '';
+    public $formularCalled = false;
+
+    public function Inicializar()
+    {
+        return $this->inicializarReturn;
+    }
+
+    public function Formular()
+    {
+        $this->formularCalled = true;
+    }
+
+    public function Novo()
+    {
+        return $this->novoReturn;
+    }
+
+    public function Editar()
+    {
+        return $this->editarReturn;
+    }
+
+    public function Excluir()
+    {
+        return $this->excluirReturn;
+    }
+
+    // Avoid calling Session facades in tests
+    protected function setFlashMessage()
+    {
+        return;
+    }
+
+    // Helper para ler a mensagem privada
+    public function getMensagem()
+    {
+        $rp = new ReflectionProperty(clsCadastro::class, '_mensagem');
+        $rp->setAccessible(true);
+        return $rp->getValue($this);
+    }
+}
+
+beforeEach(function () {
+    // limpar superglobais antes de cada teste
+    $_POST = [];
+    $_GET = [];
+    $_FILES = [];
+    // garantir que a chave 'excluir' exista para evitar warnings de índice indefinido
+    $_GET['excluir'] = $_GET['excluir'] ?? null;
+});
+
+afterEach(function () {
+    // limpar superglobais após cada teste
+    $_POST = [];
+    $_GET = [];
+    $_FILES = [];
+});
+
+it('CT-01: GET sem tipoacao chama Inicializar e Formular', function () {
+    $stub = new StubCadastro();
+    $stub->inicializarReturn = '';
+
+    $stub->Processar();
+
+    expect($stub->formularCalled)->toBeTrue();
+    expect($stub->tipoacao)->toBe('');
+});
+
+it('CT-02: Novo sucesso com script_sucesso gera script de fechamento', function () {
+    $_POST['tipoacao'] = 'Novo';
+
+    $stub = new StubCadastro();
+    $stub->novoReturn = true;
+    $stub->script_sucesso = 'alert(1);';
+
+    $stub->Processar();
+
+    expect($stub->sucesso)->toBeTrue();
+    expect($stub->script)->toContain('window.close()');
+});
+
+it('CT-03: Novo falha sem erros e sem mensagem preexistente define CAD01', function () {
+    $_POST['tipoacao'] = 'Novo';
+
+    $stub = new StubCadastro();
+    $stub->novoReturn = false;
+    $stub->erros = null;
+    // garantir que nao ha mensagem preexistente
+
+    $stub->Processar();
+
+    expect($stub->sucesso)->toBeFalse();
+    expect($stub->getMensagem())->toBe('Não foi possível inserir a informação. [CAD01]');
+});
+
+it('CT-04: Novo sucesso com script_sucesso vazio nao cria script', function () {
+    $_POST['tipoacao'] = 'Novo';
+
+    $stub = new StubCadastro();
+    $stub->novoReturn = true;
+    $stub->script_sucesso = '';
+
+    $stub->Processar();
+
+    expect($stub->sucesso)->toBeTrue();
+    // script pode ser null ou vazio; se existir, garantir que não contenha window.close()
+    Assert::assertTrue(is_null($stub->script) || $stub->script === '' || strpos($stub->script, 'window.close()') === false);
+});
+
+it('CT-05: Novo falha mesmo com script_sucesso preenchido nao cria script', function () {
+    $_POST['tipoacao'] = 'Novo';
+
+    $stub = new StubCadastro();
+    $stub->novoReturn = false;
+    $stub->script_sucesso = 'alert(1);';
+
+    $stub->Processar();
+
+    expect($stub->sucesso)->toBeFalse();
+    // script nao deve conter fechamento
+    Assert::assertTrue(is_null($stub->script) || $stub->script === '' || strpos($stub->script, 'window.close()') === false);
+});
+
+it('CT-06: Novo falha com erros nao sobrescreve mensagem padrao', function () {
+    $_POST['tipoacao'] = 'Novo';
+
+    $stub = new StubCadastro();
+    $stub->novoReturn = false;
+    $stub->erros = ['algum erro'];
+    // garantir que nao ha mensagem preexistente
+
+    $stub->Processar();
+
+    expect($stub->sucesso)->toBeFalse();
+    // Espera que _mensagem nao tenha sido preenchida com CAD01
+    expect($stub->getMensagem())->toBeNull();
+});
+
+it('CT-07: Novo falha e mensagem preexistente nao e sobrescrita', function () {
+    $_POST['tipoacao'] = 'Novo';
+
+    $stub = new StubCadastro();
+    $stub->novoReturn = false;
+    $stub->erros = null;
+    // setar mensagem preexistente diretamente no atributo privado via Reflection para evitar facades
+    $rp = new ReflectionProperty(clsCadastro::class, '_mensagem');
+    $rp->setAccessible(true);
+    $rp->setValue($stub, 'preexistente');
+
+    $stub->Processar();
+
+    expect($stub->sucesso)->toBeFalse();
+    expect($stub->getMensagem())->toBe('preexistente');
+});


### PR DESCRIPTION
**DESCRIÇÃO:**

Este pull request adiciona um conjunto completo de testes de unidade para a antiga classe clsCadastro, focando no método Processar e em como ele se comporta em diferentes situações. Os testes utilizam uma classe de simulação (stub) para não depender de componentes do Laravel (facades) nem de variáveis globais do sistema, o que garante que a execução dos testes seja isolada e confiável.

Novos testes de unidade para clsCadastro:

- Adiciona uma classe de simulação StubCadastro que herda de clsCadastro, modificando métodos essenciais para controlar o fluxo do teste e remover dependências externas.

- Implementa testes para diversos tipos de ação (como 'Novo' ou a ação padrão) e para diferentes resultados (sucesso, falha, existência de erros ou mensagens prévias) a fim de validar o correto funcionamento de scripts, mensagens e indicadores de sucesso.

- Inclui uma rotina de preparação e limpeza que zera as variáveis globais ($_POST, $_GET, $_FILES) antes e depois de cada teste, evitando que um teste interfira no outro.

- Utiliza a técnica de reflection para inspecionar e confirmar o valor da propriedade privada _mensagem, validando de forma precisa a lógica que define as mensagens de retorno.

- Assegura que a criação de scripts, o gerenciamento de erros e o sistema de mensagens operem corretamente em cenários extremos, como quando a variável script_sucesso está vazia ou quando erros são reportados.

**AMBIENTE:**

- Plataforma utilizada: Docker
- Sistema operacional e versão: Windows 10
- Navegador e versão; Chrome 141.0.7390.125