### PR TITLE
Adiciona validação de e-mail com domínio na Pessoa Jurídica (#1078)

### DIFF
--- a/ieducar/intranet/empresas_cad.php
+++ b/ieducar/intranet/empresas_cad.php
@@ -132,6 +132,13 @@ return new class extends clsCadastro
 
     public function Novo()
     {
+        if (!empty($this->email) && filter_var($this->email, FILTER_VALIDATE_EMAIL) === false) {
+            $this->mensagem = 'O campo E-mail deve conter um endereço de e-mail válido.';
+            $this->busca_empresa = true;
+
+            return false;
+        }
+
         if (!empty($this->cnpj) && validaCNPJ(cnpj: $this->cnpj) === false) {
             $this->mensagem = 'CNPJ inválido';
 
@@ -244,6 +251,13 @@ return new class extends clsCadastro
 
     public function Editar()
     {
+        if (!empty($this->email) && filter_var($this->email, FILTER_VALIDATE_EMAIL) === false) {
+            $this->mensagem = 'O campo E-mail deve conter um endereço de e-mail válido.';
+            $this->busca_empresa = true;
+
+            return false;
+        }
+
         if (!empty($this->cnpj) && validaCNPJ(cnpj: $this->cnpj) === false) {
             $this->mensagem = 'CNPJ inválido';
 


### PR DESCRIPTION
**DESCRIÇÃO:**

Este pull request resolve a issue #1078 adicionando validação de e-mail com domínio completo no cadastro de Pessoa Jurídica.

**Problema:**
O sistema permitia o cadastro de endereços de e-mail incompletos, como "contato@", sem a parte do domínio, comprometendo a integridade dos dados de contato.

**Solução Implementada:**
- Adicionada validação de e-mail usando FILTER_VALIDATE_EMAIL
- Valida formato completo: usuario@dominio.extensao
- A validação é aplicada tanto na criação quanto na edição de Pessoa Jurídica
- Exibe mensagem de erro clara ao usuário

**Alterações:**
- Métodos modificados: [Novo()] e [Editar()]
- Total: 14 linhas adicionadas

**Testes Realizados:**
- ✅ Tentativa de cadastro com email "contato@" - bloqueado
- ✅ Tentativa de cadastro com email "contato@dominio" - bloqueado
- ✅ Cadastro com email "contato@empresa.com.br" - permitido
- ✅ Cadastro com email "info@example.com" - permitido
- ✅ Campo E-mail vazio - permitido
- ✅ Edição com email inválido - bloqueado

**AMBIENTE:**

- Plataforma utilizada: Docker
- Sistema operacional: Windows 10
- Navegador: Chrome 141.0.7390.66
- Versão do i-Educar: Desenvolvimento (branch 2.10)