### PR TITLE
fix(cadastro-pf): aplica limite de 100 caracteres no campo nome. #1061

### DIFF
--- a/ieducar/intranet/atendidos_cad.php
+++ b/ieducar/intranet/atendidos_cad.php
@@ -253,7 +253,7 @@ return new class extends clsCadastro
         $this->campoOculto('obrigarCPF', (int) $obrigarCpf);
 
         $this->campoOculto(nome: 'cod_pessoa_fj', valor: $this->cod_pessoa_fj);
-        $this->campoTexto(nome: 'nm_pessoa', campo: 'Nome', valor: $this->nm_pessoa, tamanhovisivel: '50', tamanhomaximo: '255', obrigatorio: true);
+        $this->campoTexto(nome: 'nm_pessoa', campo: 'Nome', valor: $this->nm_pessoa, tamanhovisivel: '50', tamanhomaximo: '100', obrigatorio: true);
         $this->campoTexto(nome: 'nome_social', campo: 'Nome social e/ou afetivo', valor: $this->nome_social, tamanhovisivel: '50', tamanhomaximo: '255');
 
         $foto = false;

--- a/src/Modules/Educacenso/Validator/NameValidator.php
+++ b/src/Modules/Educacenso/Validator/NameValidator.php
@@ -15,6 +15,12 @@ class NameValidator implements EducacensoValidator
 
     public function isValid(): bool
     {
+        if (!empty($this->name) && mb_strlen(trim($this->name)) > 100) {
+            $this->message = 'O Nome deve ter no máximo 100 caracteres.';
+
+            return false;
+        }
+        
         if ($this->hasFourRepeatedCharaters()) {
             $this->message = 'Nome não pode ter a repetição de 4 caracteres seguidos.';
 

--- a/tests/Educacenso/Validator/NameValidatorTest.php
+++ b/tests/Educacenso/Validator/NameValidatorTest.php
@@ -28,4 +28,21 @@ class NameValidatorTest extends TestCase
         $this->assertFalse($validator->isValid());
         $this->assertStringContainsString('Nome não pode ter a repetição de 4 caracteres seguidos.', $validator->getMessage());
     }
+
+    public function test_name_with_maximum_100_characters_is_valid()
+    {
+        $name = str_repeat('Ab', 50);
+        $validator = new NameValidator($name);
+
+        $this->assertTrue($validator->isValid());
+    }
+
+    public function test_name_longer_than_100_characters_is_invalid()
+    {
+        $name = str_repeat('AB', 51);
+        $validator = new NameValidator($name);
+
+        $this->assertFalse($validator->isValid());
+        $this->assertStringContainsString('O Nome deve ter no máximo 100 caracteres', $validator->getMessage());
+    }
 }


### PR DESCRIPTION
**DESCRIÇÃO:**
- **Relacionado a issue #1061** 
- Adiciona validação para garantir que o campo Nome não ultrapasse 100 caracteres e exibir mensagem de erro quando isso ocorrer;
- Ajusta campo do formulário para reforço client-side (tamanhomaximo = 100);
- Adiciona testes unitários do NameValidator.
<img width="511" height="169" alt="testeunitarioIEducar" src="https://github.com/user-attachments/assets/afa067d9-76b4-4bd7-8e0b-0f3400db01d0" />


Descreva o ambiente em que este pull request foi criado.

- Plataforma utilizada: instalação direta
- Sistema operacional e versão: Ubuntu 25.04
- Navegador e versão: Google Chrome 141.0.7390.122 (Versão oficial) 64 bits
