### PR TITLE
feat: adiciona mensagem de sucesso após cadastro de pessoa física

### DIFF
--- a/ieducar/intranet/atendidos_cad.php
+++ b/ieducar/intranet/atendidos_cad.php
@@ -1089,6 +1089,12 @@ return new class extends clsCadastro
         $this->createOrUpdateDocumentos(pessoaId: $pessoaId);
         $this->createOrUpdateTelefones(pessoaId: $pessoaId);
         $this->saveAddress(person: $pessoaId, optionalFields: true);
+        
+        // Issue #1059: Adicionar mensagem de sucesso para novos cadastros
+        if ($pessoaIdOrNull === null) {
+            session()->flash('success', 'Pessoa cadastrada com sucesso.');
+        }
+        
         $this->afterChangePessoa(id: $pessoaId);
         $this->saveFiles(idpes: $pessoaId);
 

--- a/tests/Feature/LegacyIndividualRegistrationTest.php
+++ b/tests/Feature/LegacyIndividualRegistrationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
+
+class LegacyIndividualRegistrationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * CICLO 1 - RED → GREEN
+     * 
+     * Testa se a flash message de sucesso é criada quando
+     * $pessoaIdOrNull é null (indicando novo cadastro).
+     * 
+     * @return void
+     */
+    public function test_should_create_success_flash_message_for_new_registration(): void
+    {
+        $pessoaIdOrNull = null;
+        
+        if ($pessoaIdOrNull === null) {
+            session()->flash('success', 'Pessoa cadastrada com sucesso.');
+        }
+        $this->assertTrue(
+            Session::has('success'),
+            'A flash message "success" não foi criada na sessão.'
+        );
+        
+        $this->assertEquals(
+            'Pessoa cadastrada com sucesso.',
+            session('success'),
+            'A mensagem de sucesso não corresponde ao esperado.'
+        );
+    }
+    
+    /**
+     * CICLO 1 - Teste complementar
+     * 
+     * Testa se a flash message NÃO é criada quando
+     * $pessoaIdOrNull tem um valor (indicando edição).
+     * 
+     * @return void
+     */
+    public function test_should_not_create_success_flash_message_for_edit(): void
+    {
+        $pessoaIdOrNull = 123;
+        
+        if ($pessoaIdOrNull === null) {
+            session()->flash('success', 'Pessoa cadastrada com sucesso.');
+        }
+
+        $this->assertFalse(
+            Session::has('success'),
+            'A flash message "success" não deveria ser criada para edição.'
+        );
+    }
+    
+    /**
+     * CICLO 2 - RED
+     * 
+     * Testa se a mensagem de sucesso termina com ponto final,
+     * seguindo o padrão de outras mensagens do sistema.
+     * 
+     * @return void
+     */
+    public function test_success_message_should_end_with_period(): void
+    {
+        // Arrange: Simular novo cadastro
+        $pessoaIdOrNull = null;
+        
+        if ($pessoaIdOrNull === null) {
+            session()->flash('success', 'Pessoa cadastrada com sucesso.');
+        }
+        
+        $message = session('success');
+        
+        // Assert: Verificar que a mensagem termina com ponto
+        $this->assertStringEndsWith(
+            '.',
+            $message,
+            'A mensagem de sucesso deve terminar com ponto final.'
+        );
+        
+        // Assert: Verificar que não tem espaços extras no final
+        $this->assertEquals(
+            trim($message),
+            $message,
+            'A mensagem não deve ter espaços em branco extras.'
+        );
+    }
+    
+    /**
+     * CICLO 3 - RED
+     * 
+     * Testa se a mensagem contém palavras-chave importantes
+     * que comuniquem claramente o resultado da ação.
+     * 
+     * @return void
+     */
+    public function test_success_message_should_contain_key_words(): void
+    {
+        // Arrange: Simular novo cadastro
+        $pessoaIdOrNull = null;
+        
+        if ($pessoaIdOrNull === null) {
+            session()->flash('success', 'Pessoa cadastrada com sucesso.');
+        }
+        
+        $message = session('success');
+        
+        // Assert: Verificar que contém a palavra "cadastrada"
+        $this->assertStringContainsString(
+            'cadastrada',
+            $message,
+            'A mensagem deve conter a palavra "cadastrada" para indicar a ação realizada.'
+        );
+        
+        // Assert: Verificar que contém a palavra "sucesso"
+        $this->assertStringContainsString(
+            'sucesso',
+            $message,
+            'A mensagem deve conter a palavra "sucesso" para indicar resultado positivo.'
+        );
+    }
+    
+    /**
+     * CICLO 4 - RED
+     * 
+     * Testa se a mensagem tem tamanho adequado (não muito curta, não muito longa)
+     * para boa legibilidade e usabilidade.
+     * 
+     * @return void
+     */
+    public function test_success_message_should_have_appropriate_length(): void
+    {
+        // Arrange: Simular novo cadastro
+        $pessoaIdOrNull = null;
+        
+        if ($pessoaIdOrNull === null) {
+            session()->flash('success', 'Pessoa cadastrada com sucesso.');
+        }
+        
+        $message = session('success');
+        
+        // Assert: Mensagem deve ter no mínimo 10 caracteres
+        $this->assertGreaterThanOrEqual(
+            10,
+            strlen($message),
+            'A mensagem é muito curta para ser informativa.'
+        );
+        
+        // Assert: Mensagem deve ter no máximo 100 caracteres
+        $this->assertLessThanOrEqual(
+            100,
+            strlen($message),
+            'A mensagem é muito longa, pode prejudicar a usabilidade.'
+        );
+    }
+}


### PR DESCRIPTION
Implementa feedback visual ao usuário após cadastro bem-sucedido de pessoa física, resolvendo problema de usabilidade onde o sistema não informava ao usuário que a operação foi concluída com sucesso.

Fixes #1059

**DESCRIÇÃO:**


Implementa feedback visual ao usuário após cadastro bem-sucedido de pessoa física, resolvendo problema de usabilidade onde o sistema não informava ao usuário que a operação foi concluída com sucesso.

Problema:

Conforme relatado na issue #1059, quando um usuário cadastra uma nova pessoa física no sistema através do menu "Cadastros > Pessoas > Pessoas físicas > Novo", o sistema processa e salva os dados corretamente, mas não exibe nenhuma mensagem de confirmação. Isso pode causar confusão e até levar o usuário a cadastrar a mesma pessoa duplicadamente por incerteza se o cadastro foi concluído.

Solução:

Adiciona uma flash message de sucesso utilizando o mecanismo nativo do Laravel (`session()->flash()`) que já é utilizado em outras partes do sistema, garantindo consistência visual.

**Mudanças implementadas:**
- Mensagem "Pessoa cadastrada com sucesso." exibida apenas para **novos cadastros**
- Nenhuma mensagem para **edições** (comportamento correto mantido)
- Utiliza o sistema de flash messages já existente no i-Educar

Implementação:

**Arquivo modificado:** `ieducar/intranet/atendidos_cad.php`

Código adicionado no método `createOrUpdate()` após salvar o endereço e antes do callback:

```php
// Issue #1059: Adicionar mensagem de sucesso para novos cadastros
if ($pessoaIdOrNull === null) {
    session()->flash('success', 'Pessoa cadastrada com sucesso.');
}
**AMBIENTE:**

- Plataforma utilizada (Instalação direta)
- Sistema operacional e versão (Apple M4)
- Navegador e versão (Chrome)
