### PR TITLE
feat: adicionar "AbsenceDelayRequest" e os respectivos testes unitários para as regras de validação.

### DIFF
--- a/app/Http/Requests/AbsenceDelayRequest.php
+++ b/app/Http/Requests/AbsenceDelayRequest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * FormRequest para validação de Falta/Atraso de Servidor
+ *
+ * Este Request implementa as regras de validação para os campos
+ * do formulário de cadastro/edição de falta/atraso de servidor.
+ *
+ * Funcionalidades implementadas:
+ * - Validação de valores não-negativos para horas e minutos
+ * - Validação de campos obrigatórios
+ * - Mensagens de erro personalizadas e amigáveis
+ *
+ * @package App\Http\Requests
+ * @author Sistema I-Educar
+ * @version 1.0.0
+ */
+class AbsenceDelayRequest extends FormRequest
+{
+    /**
+     * Determina se o usuário está autorizado a fazer esta requisição.
+     *
+     * Por padrão, retorna true. Pode ser customizado para incluir
+     * lógica de autorização específica se necessário.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Obtém as regras de validação que devem ser aplicadas à requisição.
+     *
+     * Regras implementadas:
+     * - tipo: obrigatório e deve ser inteiro
+     * - qtd_horas: opcional, mas se fornecido deve ser inteiro >= 0
+     * - qtd_min: opcional, mas se fornecido deve ser inteiro >= 0
+     * - ref_cod_servidor_funcao: obrigatório e deve ser inteiro
+     * - data_falta_atraso: obrigatório e deve estar no formato dd/mm/yyyy
+     *
+     * @return array<string, array<int, string|int>> Array associativo com as regras de validação
+     */
+    public function rules(): array
+    {
+        return [
+            'tipo' => ['required', 'integer'],
+            'qtd_horas' => ['nullable', 'integer', 'min:0'],
+            'qtd_min' => ['nullable', 'integer', 'min:0'],
+            'ref_cod_servidor_funcao' => ['required', 'integer'],
+            'data_falta_atraso' => ['required', 'date_format:d/m/Y'],
+        ];
+    }
+
+    /**
+     * Obtém as mensagens de validação personalizadas.
+     *
+     * Fornece mensagens de erro claras e em português para melhorar
+     * a experiência do usuário ao identificar problemas de validação.
+     *
+     * @return array<string, string> Array associativo com as mensagens personalizadas
+     */
+    public function messages(): array
+    {
+        return [
+            // Mensagens para validação de horas
+            'qtd_horas.integer' => 'O campo Quantidade de Horas deve ser um número inteiro.',
+            'qtd_horas.min' => 'O campo Quantidade de Horas não pode ser negativo.',
+
+            // Mensagens para validação de minutos
+            'qtd_min.integer' => 'O campo Quantidade de Minutos deve ser um número inteiro.',
+            'qtd_min.min' => 'O campo Quantidade de Minutos não pode ser negativo.',
+
+            // Mensagens para outros campos obrigatórios
+            'tipo.required' => 'O campo Tipo é obrigatório.',
+            'data_falta_atraso.required' => 'O campo Dia é obrigatório.',
+            'data_falta_atraso.date_format' => 'O campo Dia deve estar no formato dia/mês/ano (ex: 01/01/2024).',
+            'ref_cod_servidor_funcao.required' => 'O campo Função é obrigatório.',
+        ];
+    }
+
+    /**
+     * Obtém os nomes personalizados dos atributos para mensagens de validação.
+     *
+     * Define nomes amigáveis para os campos que serão usados nas
+     * mensagens de validação automáticas do Laravel.
+     *
+     * @return array<string, string> Array associativo com os nomes dos atributos
+     */
+    public function attributes(): array
+    {
+        return [
+            'qtd_horas' => 'Quantidade de Horas',
+            'qtd_min' => 'Quantidade de Minutos',
+            'tipo' => 'Tipo',
+            'data_falta_atraso' => 'Dia',
+            'ref_cod_servidor_funcao' => 'Função',
+        ];
+    }
+}

--- a/tests/Unit/Http/Requests/AbsenceDelayRequestTest.php
+++ b/tests/Unit/Http/Requests/AbsenceDelayRequestTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Unit\Http\Requests;
+
+use App\Http\Requests\AbsenceDelayRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+/**
+ * Testes unitários para validação de Falta/Atraso de Servidor
+ *
+ * Esta suite de testes implementa a metodologia TDD (Test-Driven Development)
+ * para garantir a validação correta dos campos de quantidade de horas e minutos
+ * no formulário de cadastro de falta/atraso de servidor.
+ *
+ * Ciclo TDD seguido:
+ * 1. RED: Escrever teste que falha
+ * 2. GREEN: Implementar código mínimo para passar
+ * 3. REFACTOR: Melhorar código mantendo testes verdes
+ *
+ * Regra de negócio testada:
+ * - Os campos qtd_horas e qtd_min devem aceitar apenas valores >= 0
+ * - Valores negativos devem ser rejeitados com mensagem de erro clara
+ * - Valores zero e positivos devem ser aceitos
+ *
+ * @package Tests\Unit\Http\Requests
+ * @author Sistema I-Educar
+ * @version 1.0.0
+ */
+class AbsenceDelayRequestTest extends TestCase
+{
+    /**
+     * CICLO 1 - GREEN
+     * Teste: Horas não podem ser negativas
+     *
+     * Este teste valida que o campo qtd_horas não aceita valores negativos.
+     * Comportamento esperado: Validação deve falhar com mensagem de erro específica.
+     *
+     * @return void
+     */
+    public function test_horas_nao_podem_ser_negativas()
+    {
+        // Arrange - Preparar os dados de teste com horas negativas
+        $request = new AbsenceDelayRequest();
+        $rules = $request->rules();
+
+        $data = [
+            'tipo' => 1,
+            'qtd_horas' => -5,
+            'qtd_min' => 0,
+            'data_falta_atraso' => '01/01/2024',
+            'ref_cod_servidor_funcao' => 1,
+        ];
+
+        // Act - Executar a validação
+        $validator = Validator::make($data, $rules, $request->messages());
+
+        // Assert - Verificar que a validação falhou
+        $this->assertTrue(
+            $validator->fails(),
+            'A validação deveria falhar para horas negativas'
+        );
+
+        // Verificar que existe erro específico no campo qtd_horas
+        $this->assertTrue(
+            $validator->errors()->has('qtd_horas'),
+            'Deveria existir erro no campo qtd_horas'
+        );
+    }
+
+    /**
+     * CICLO 2 - GREEN
+     * Teste: Minutos não podem ser negativos
+     *
+     * Este teste valida que o campo qtd_min não aceita valores negativos.
+     * Comportamento esperado: Validação deve falhar com mensagem de erro específica.
+     *
+     * @return void
+     */
+    public function test_minutos_nao_podem_ser_negativos()
+    {
+        // Arrange - Preparar os dados de teste com minutos negativos
+        $request = new AbsenceDelayRequest();
+        $rules = $request->rules();
+
+        $data = [
+            'tipo' => 1,
+            'qtd_horas' => 0,
+            'qtd_min' => -30,
+            'data_falta_atraso' => '01/01/2024',
+            'ref_cod_servidor_funcao' => 1,
+        ];
+
+        // Act - Executar a validação
+        $validator = Validator::make($data, $rules, $request->messages());
+
+        // Assert - Verificar que a validação falhou
+        $this->assertTrue(
+            $validator->fails(),
+            'A validação deveria falhar para minutos negativos'
+        );
+
+        // Verificar que existe erro específico no campo qtd_min
+        $this->assertTrue(
+            $validator->errors()->has('qtd_min'),
+            'Deveria existir erro no campo qtd_min'
+        );
+    }
+
+    /**
+     * CICLO 3 - GREEN
+     * Teste: Valores positivos ou zero são válidos
+     *
+     * Este teste valida que o sistema aceita valores válidos (positivos ou zero)
+     * para os campos qtd_horas e qtd_min.
+     * Comportamento esperado: Validação deve passar sem erros.
+     *
+     * @return void
+     */
+    public function test_valores_positivos_ou_zero_sao_validos()
+    {
+        // Arrange - Preparar os dados de teste com valores válidos
+        $request = new AbsenceDelayRequest();
+        $rules = $request->rules();
+
+        // Teste 1: Valores positivos normais
+        $data1 = [
+            'tipo' => 1,
+            'qtd_horas' => 10,
+            'qtd_min' => 59,
+            'data_falta_atraso' => '01/01/2024',
+            'ref_cod_servidor_funcao' => 1,
+        ];
+
+        // Teste 2: Valores zero
+        $data2 = [
+            'tipo' => 1,
+            'qtd_horas' => 0,
+            'qtd_min' => 0,
+            'data_falta_atraso' => '01/01/2024',
+            'ref_cod_servidor_funcao' => 1,
+        ];
+
+        // Act - Executar as validações
+        $validator1 = Validator::make($data1, $rules, $request->messages());
+        $validator2 = Validator::make($data2, $rules, $request->messages());
+
+        // Assert - Verificar que as validações passaram
+        $this->assertFalse(
+            $validator1->fails(),
+            'A validação deveria passar para valores positivos válidos'
+        );
+
+        $this->assertFalse(
+            $validator2->fails(),
+            'A validação deveria passar para valores zero'
+        );
+    }
+}


### PR DESCRIPTION
**DESCRIÇÃO:**

Este PR implementa a validação dos campos Quantidade de Horas (qtd_horas) e Quantidade de Minutos (qtd_min) no formulário de Falta/Atraso de Servidor (Servidores > Falta/Atraso > Novo/Editar), garantindo que apenas valores não-negativos (maiores ou iguais a zero) sejam aceitos.
A funcionalidade corrige a falha de validação descrita na Issue #1098. Anteriormente, o sistema permitia salvar registros com quantidades negativas de horas ou minutos, o que comprometia a integridade dos dados e o sentido lógico do registro.

**AMBIENTE:**

Descreva o ambiente em que este pull request foi criado.

- Plataforma utilizada (Docker, instalação direta): Docker
- Sistema operacional e versão: macOS Sonoma 14.4 (Host) / Debian (Docker Container)
- Navegador e versão: Chrome 120.0
- Outros detalhes importantes: PHP 8.4 com Laravel Framework. Testes executados via Pest (PHPUnit).

