### PR TITLE
fix(routes): redireciona / e intranet/index.php direto para educar_index.php

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -14,11 +14,11 @@ use Illuminate\Support\Facades\Route;
 
 Auth::routes(['register' => false]);
 
-Route::redirect('/', '/web');
+Route::redirect('/', '/intranet/educar_index.php');
 
 Route::view('/docs-api', 'docs/api/index');
 
-Route::redirect('intranet/index.php', '/web')
+Route::redirect('intranet/index.php', '/intranet/educar_index.php')
     ->name('home');
 
 Route::any('module/Api/{uri}', 'LegacyController@api')->where('uri', '.*');


### PR DESCRIPTION
## DESCRIÇÃO

### Problema

Em `routes/web.php` (linhas 17 e 21), os dois redirects de boas-vindas apontam para `/web`:

```php
Route::redirect('/', '/web');
Route::redirect('intranet/index.php', '/web')->name('home');
```

Mas `/web` não é uma rota concreta — não existe nem como rota Laravel, nem como diretório em `public/web/`, nem como SPA buildada. O caminho `/web` só é "atendido" porque o `WebController::fallback` (registrado dentro do grupo `auth` em `routes/web.php:199`) intercepta a 404 e faz mais um redirect:

```php
public function fallback($uri)
{
    if (str_starts_with($uri, 'web')) {
        return redirect('intranet/educar_index.php');
    }
    return abort(404);
}
```

Resultado: usuário autenticado abrindo a raiz tem **3 redirects 302 em sequência** (`/` → `/web` → fallback → `/intranet/educar_index.php`), poluindo o histórico do navegador e dando a impressão de instabilidade.

Pior: em **versões anteriores (linha 2.7.x)** onde o `WebController::fallback` ainda não existia, esse mesmo redirect resulta em **404 hard logo após o login**, deixando o sistema inacessível. Esse comportamento foi observado em uma instalação 2.7.4 em produção, onde o usuário logava e era jogado em uma página "Página não encontrada" sem ação possível.

### Solução implementada

Apontar os dois `Route::redirect` diretamente para `/intranet/educar_index.php`, eliminando o salto intermediário por `/web`.

### Alterações

- `routes/web.php`: 2 linhas alteradas, sem novas dependências, sem mudança de assinatura nem de nome de rota (`->name('home')` preservado).

### Por que não remover o `WebController::fallback` também?

Por segurança. O fallback continua útil como rede para qualquer link/bookmark legado que aponte para `/web/...`. Esta PR é deliberadamente mínima.

### Compatibilidade

- Sem breaking change. A rota nomeada `home` continua existindo com o mesmo nome; só o destino do redirect mudou.
- Cobre integralmente o cenário atendido pelo fallback hoje.

### Testes realizados

- Aplicado em produção (i-Educar 2.7.4) onde o redirect para `/web` retornava 404 hard. Após a alteração, login e acesso à tela inicial funcionam normalmente.
- `php artisan route:list` continua listando a rota `home` corretamente.
- `php artisan route:cache` sem erros.

### AMBIENTE de validação

- **Plataforma:** i-Educar 2.7.4 em CapRover
- **SO:** Debian 13 (host) / Alpine (container)
- **PHP:** 8.1.8
- **PostgreSQL:** 14.22
- **Navegadores:** Chrome 138, Firefox 130