### PR TITLE
Exige CPF no cadastro de pessoa e no cadastro simplificado (pai/mãe/responsável) quando "Exigir CPF" está ativo

### DIFF
--- a/ieducar/intranet/atendidos_cad.php
+++ b/ieducar/intranet/atendidos_cad.php
@@ -226,8 +226,6 @@ return new class extends clsCadastro
             }
         }
 
-        $this->campoCpf(nome: 'id_federal', campo: 'CPF', valor: $this->id_federal);
-
         $user = Auth::user();
 
         if ($user->ref_cod_instituicao) {
@@ -237,6 +235,8 @@ return new class extends clsCadastro
             $obrigarCpf = LegacyInstitution::query()
                 ->first(['obrigar_cpf'])?->obrigar_cpf;
         }
+
+        $this->campoCpf(nome: 'id_federal', campo: 'CPF', valor: $this->id_federal, obrigatorio: (bool) $obrigarCpf);
 
         $this->campoOculto('obrigarCPF', (int) $obrigarCpf);
 

--- a/ieducar/modules/Api/Views/PessoaController.php
+++ b/ieducar/modules/Api/Views/PessoaController.php
@@ -304,7 +304,7 @@ class PessoaController extends ApiCoreController
     protected function loadPessoaParent()
     {
         if ($this->getRequest()->id) {
-            $_sql = ' SELECT (select nome from cadastro.pessoa where pessoa.idpes = fisica.idpes) as nome ,ideciv as estadocivil, data_nasc, sexo, falecido FROM cadastro.fisica WHERE idpes = $1; ';
+            $_sql = ' SELECT (select nome from cadastro.pessoa where pessoa.idpes = fisica.idpes) as nome ,ideciv as estadocivil, data_nasc, sexo, falecido, cpf FROM cadastro.fisica WHERE idpes = $1; ';
 
             $details = $this->fetchPreparedQuery($_sql, $this->getRequest()->id, false, 'first-row');
 
@@ -312,6 +312,7 @@ class PessoaController extends ApiCoreController
             $details['nome'] = Portabilis_String_Utils::toUtf8($details['nome']);
             $details['id'] = $this->getRequest()->id;
             $details['falecido'] = dbBool($details['falecido']);
+            $details['cpf'] = $details['cpf'] ? int2CPF($details['cpf']) : '';
 
             return $details;
         } else {
@@ -537,9 +538,45 @@ class PessoaController extends ApiCoreController
         return true;
     }
 
+    private function validateCpf()
+    {
+        $cpf = $this->getRequest()->cpf;
+
+        $user = Auth::user();
+        $obrigarCpf = $user->ref_cod_instituicao
+            ? LegacyInstitution::query()->find($user->ref_cod_instituicao, ['obrigar_cpf'])?->obrigar_cpf
+            : LegacyInstitution::query()->first(['obrigar_cpf'])?->obrigar_cpf;
+
+        if (empty($cpf)) {
+            if ($obrigarCpf) {
+                $this->messenger->append('É necessário o preenchimento do CPF.');
+
+                return false;
+            }
+
+            return true;
+        }
+
+        if (!Portabilis_Utils_Validation::validatesCpf(cpf: $cpf)) {
+            $this->messenger->append('CPF inválido.');
+
+            return false;
+        }
+
+        $existing = LegacyIndividual::findByCpf($cpf);
+
+        if ($existing && (int) $existing->idpes !== (int) $this->getRequest()->pessoa_id) {
+            $this->messenger->append("CPF já utilizado pela pessoa {$existing->idpes}.");
+
+            return false;
+        }
+
+        return true;
+    }
+
     protected function canPost()
     {
-        return $this->validateName() && $this->validaNomeSocial() && $this->validateBirthDate() && $this->validateDifferentiatedLocation();
+        return $this->validateName() && $this->validaNomeSocial() && $this->validateBirthDate() && $this->validateDifferentiatedLocation() && $this->validateCpf();
     }
 
     protected function post()
@@ -600,6 +637,11 @@ class PessoaController extends ApiCoreController
             $povo_indigena_educacenso_id = $this->getRequest()->povo_indigena_educacenso_id;
         }
         $individual->povo_indigena_educacenso_id = $povo_indigena_educacenso_id;
+
+        $cpf = $this->getRequest()->cpf;
+        if (!empty($cpf)) {
+            $individual->cpf = idFederal2int(str: $cpf);
+        }
 
         $individual->saveOrFail();
 

--- a/ieducar/modules/Api/Views/PessoaController.php
+++ b/ieducar/modules/Api/Views/PessoaController.php
@@ -541,11 +541,7 @@ class PessoaController extends ApiCoreController
     private function validateCpf()
     {
         $cpf = $this->getRequest()->cpf;
-
-        $user = Auth::user();
-        $obrigarCpf = $user->ref_cod_instituicao
-            ? LegacyInstitution::query()->find($user->ref_cod_instituicao, ['obrigar_cpf'])?->obrigar_cpf
-            : LegacyInstitution::query()->first(['obrigar_cpf'])?->obrigar_cpf;
+        $obrigarCpf = app(LegacyInstitution::class)->obrigar_cpf;
 
         if (empty($cpf)) {
             if ($obrigarCpf) {

--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/Aluno.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/Aluno.js
@@ -1916,6 +1916,8 @@ function canShowParentsFields() {
                   <td valign="top">
                     <fieldset>
                       <legend>Dados básicos</legend>
+                      <label for="cpf-pessoa-aluno">CPF</label>
+                      <input type="text" name="cpf-pessoa-aluno" id="cpf-pessoa-aluno" size="16" maxlength="14" class="text" placeholder="000.000.000-00">
                       <label for="nome-pessoa-aluno">Nome<span class="campo_obrigatorio">*</span> </label>
                       <input type="text" name="nome-pessoa-aluno" id="nome-pessoa-aluno" size="49" maxlength="255" class="text">
                       <label for="nome-social-pessoa-aluno">Nome social e/ou afetivo</label>
@@ -2045,6 +2047,7 @@ function canShowParentsFields() {
       apartamento = $j("#apartamento"),
       bloco = $j("#bloco"),
       andar = $j("#andar"),
+      cpfAluno = $j("#cpf-pessoa-aluno"),
       allFields = $j([])
         .add(name)
         .add(observacao)
@@ -2063,7 +2066,19 @@ function canShowParentsFields() {
         .add(letra)
         .add(apartamento)
         .add(bloco)
-        .add(andar);
+        .add(andar)
+        .add(cpfAluno);
+
+    // CPF obrigatorio no modal do aluno quando o parametro "Exigir CPF" esta ativo
+    var obrigarCPFModalAluno = obrigarCPF.val() == 1;
+
+    if ($j.fn.mask) {
+      cpfAluno.mask("000.000.000-00");
+    }
+
+    if (obrigarCPFModalAluno) {
+      $j('label[for="cpf-pessoa-aluno"]').append(' <span style="color:#cc0000">*</span>');
+    }
 
     municipio
       .show()
@@ -2403,6 +2418,21 @@ function canShowParentsFields() {
               );
           }
 
+          var cpfValAluno = cpfAluno.val().trim();
+          if (obrigarCPFModalAluno && cpfValAluno === "") {
+            bValid = false;
+            cpfAluno.addClass("error");
+            messageUtils.error("O campo CPF é obrigatório.");
+          } else if (
+            cpfValAluno !== "" &&
+            typeof validationUtils !== "undefined" &&
+            !validationUtils.validatesCpf(cpfValAluno)
+          ) {
+            bValid = false;
+            cpfAluno.addClass("error");
+            messageUtils.error("CPF inválido.");
+          }
+
           if (bValid) {
             postPessoa(
               $j(this),
@@ -2427,6 +2457,7 @@ function canShowParentsFields() {
               nome_social.val(),
               $j("#pais_residencia").val(),
               $j("#povo_indigena_educacenso_id").val(),
+              cpfAluno.val().trim()
             );
           }
         },
@@ -2454,7 +2485,7 @@ function canShowParentsFields() {
     });
 
     $j("body").append(
-      '<div id="dialog-form-pessoa-parent"><form><h2></h2><table><tr><td valign="top"><fieldset><label for="nome-pessoa-parent">Nome</label>    <input type="text " name="nome-pessoa-parent" id="nome-pessoa-parent" size="49" maxlength="255" class="text">    <label for="sexo-pessoa-parent">Sexo</label>  <select class="select ui-widget-content ui-corner-all" name="sexo-pessoa-parent" id="sexo-pessoa-parent" ><option value="" selected>Sexo</option><option value="M">Masculino</option><option value="F">Feminino</option></select>    <label for="estado-civil-pessoa-parent">Estado civil</label>   <select class="select ui-widget-content ui-corner-all" name="estado-civil-pessoa-parent" id="estado-civil-pessoa-parent"  ><option id="estado-civil-pessoa-parent_" value="" selected>Estado civil</option><option id="estado-civil-pessoa-parent_2" value="2">Casado(a)</option><option id="estado-civil-pessoa-parent_6" value="6">Companheiro(a)</option><option id="estado-civil-pessoa-parent_3" value="3">Divorciado(a)</option><option id="estado-civil-pessoa-parent_4" value="4">Separado(a)</option><option id="estado-civil-pessoa-parent_1" value="1">Solteiro(a)</option><option id="estado-civil-pessoa-parent_5" value="5">Vi&uacute;vo(a)</option><option id="estado-civil-pessoa-parent_7" value="7">Não informado</option></select><label for="data-nasc-pessoa-parent"> Data de nascimento </label> <input onKeyPress="formataData(this, event);" class="" placeholder="dd/mm/yyyy" type="text" name="data-nasc-pessoa-parent" id="data-nasc-pessoa-parent" value="" size="11" maxlength="10"> <div id="falecido-modal"> <label>Falecido?</label><input type="checkbox" name="falecido-parent" id="falecido-parent" style="display:inline;"> </div></fieldset><p><a id="link_cadastro_detalhado_parent">Cadastro detalhado</a></p></form></div>'
+      '<div id="dialog-form-pessoa-parent"><form><h2></h2><table><tr><td valign="top"><fieldset><label for="cpf-pessoa-parent">CPF</label> <input type="text" name="cpf-pessoa-parent" id="cpf-pessoa-parent" size="16" maxlength="14" class="text" placeholder="000.000.000-00"> <label for="nome-pessoa-parent">Nome</label>    <input type="text " name="nome-pessoa-parent" id="nome-pessoa-parent" size="49" maxlength="255" class="text">    <label for="sexo-pessoa-parent">Sexo</label>  <select class="select ui-widget-content ui-corner-all" name="sexo-pessoa-parent" id="sexo-pessoa-parent" ><option value="" selected>Sexo</option><option value="M">Masculino</option><option value="F">Feminino</option></select>    <label for="estado-civil-pessoa-parent">Estado civil</label>   <select class="select ui-widget-content ui-corner-all" name="estado-civil-pessoa-parent" id="estado-civil-pessoa-parent"  ><option id="estado-civil-pessoa-parent_" value="" selected>Estado civil</option><option id="estado-civil-pessoa-parent_2" value="2">Casado(a)</option><option id="estado-civil-pessoa-parent_6" value="6">Companheiro(a)</option><option id="estado-civil-pessoa-parent_3" value="3">Divorciado(a)</option><option id="estado-civil-pessoa-parent_4" value="4">Separado(a)</option><option id="estado-civil-pessoa-parent_1" value="1">Solteiro(a)</option><option id="estado-civil-pessoa-parent_5" value="5">Vi&uacute;vo(a)</option><option id="estado-civil-pessoa-parent_7" value="7">Não informado</option></select><label for="data-nasc-pessoa-parent"> Data de nascimento </label> <input onKeyPress="formataData(this, event);" class="" placeholder="dd/mm/yyyy" type="text" name="data-nasc-pessoa-parent" id="data-nasc-pessoa-parent" value="" size="11" maxlength="10"> <div id="falecido-modal"> <label>Falecido?</label><input type="checkbox" name="falecido-parent" id="falecido-parent" style="display:inline;"> </div></fieldset><p><a id="link_cadastro_detalhado_parent">Cadastro detalhado</a></p></form></div>'
     );
 
     $j("#dialog-form-pessoa-parent").find(":input").css("display", "block");
@@ -2464,12 +2495,25 @@ function canShowParentsFields() {
       estadocivilParent = $j("#estado-civil-pessoa-parent"),
       datanascParent = $j("#data-nasc-pessoa-parent"),
       falecidoParent = $j("#falecido-parent"),
+      cpfParent = $j("#cpf-pessoa-parent"),
       allFields = $j([])
         .add(nameParent)
         .add(sexoParent)
         .add(estadocivilParent)
         .add(datanascParent)
-        .add(falecidoParent);
+        .add(falecidoParent)
+        .add(cpfParent);
+
+    // CPF obrigatorio no modal quando o parametro da instituicao "Exigir CPF" esta ativo
+    var obrigarCPFModalParent = obrigarCPF.val() == 1;
+
+    if ($j.fn.mask) {
+      cpfParent.mask("000.000.000-00");
+    }
+
+    if (obrigarCPFModalParent) {
+      $j('label[for="cpf-pessoa-parent"]').append(' <span style="color:#cc0000">*</span>');
+    }
 
     $j("#dialog-form-pessoa-parent").dialog({
       autoOpen: false,
@@ -2499,6 +2543,21 @@ function canShowParentsFields() {
               );
           }
 
+          var cpfValParent = cpfParent.val().trim();
+          if (obrigarCPFModalParent && cpfValParent === "") {
+            bValid = false;
+            cpfParent.addClass("error");
+            messageUtils.error("O campo CPF é obrigatório.");
+          } else if (
+            cpfValParent !== "" &&
+            typeof validationUtils !== "undefined" &&
+            !validationUtils.validatesCpf(cpfValParent)
+          ) {
+            bValid = false;
+            cpfParent.addClass("error");
+            messageUtils.error("CPF inválido.");
+          }
+
           if (bValid) {
             postPessoa(
               $(this),
@@ -2516,7 +2575,16 @@ function canShowParentsFields() {
               null,
               null,
               null,
-              falecidoParent.is(":checked")
+              falecidoParent.is(":checked"),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              cpfParent.val().trim()
             );
           }
         },
@@ -2983,10 +3051,12 @@ function canShowParentsFields() {
     localizacao_diferenciada,
     nome_social,
     pais_residencia,
-    povo_indigena_educacenso_id
+    povo_indigena_educacenso_id,
+    cpf
   ) {
     var data = {
       nome: nome,
+      cpf: cpf,
       sexo: sexo,
       estadocivil: estadocivil,
       datanasc: datanasc,

--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/Aluno.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/Aluno.js
@@ -2657,6 +2657,7 @@ function canShowParentsFields() {
       datanasc.val(person_details.data_nascimento);
       estadocivil.val(person_details.estadocivil);
       sexo.val(person_details.sexo);
+      cpfAluno.val(person_details.cpf || "");
 
       if (person_details.idmun_nascimento) {
         $j("#naturalidade_aluno_id").val(
@@ -2842,6 +2843,7 @@ function canShowParentsFields() {
         "checked",
         window[parentType + "_details"].falecido
       );
+      cpfParent.val(window[parentType + "_details"].cpf || "");
 
       if (parentType == "responsavel") {
         $j("#falecido-modal").hide();

--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/ModalCadastroPais.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/ModalCadastroPais.js
@@ -107,6 +107,7 @@ function openEditModalParent(parentType) {
     sexoParent.val(personDetails.sexo);
     datanascParent.val(personDetails.data_nascimento);
     falecidoParent.prop('checked', (personDetails.falecido));
+    cpfParent.val(personDetails.cpf || '');
 
     $j('#dialog-form-pessoa-parent form h2:first-child').html('Editar pessoa ' + (parentType == 'mae' ? 'mãe' : parentType)).css('margin-left', '0.75em');
 
@@ -114,7 +115,7 @@ function openEditModalParent(parentType) {
     editar_pessoa = true;
 }
 
-$j('body').append('<div id="dialog-form-pessoa-parent"><form><h2></h2><table><tr><td valign="top"><fieldset><label for="nome-pessoa-parent">Nome</label>    <input type="text " name="nome-pessoa-parent" id="nome-pessoa-parent" size="49" maxlength="255" class="text">    <label for="sexo-pessoa-parent">Sexo</label>  <select class="select ui-widget-content ui-corner-all" name="sexo-pessoa-parent" id="sexo-pessoa-parent" ><option value="" selected>Sexo</option><option value="M">Masculino</option><option value="F">Feminino</option></select>    <label for="estado-civil-pessoa-parent">Estado civil</label>   <select class="select ui-widget-content ui-corner-all" name="estado-civil-pessoa-parent" id="estado-civil-pessoa-parent"  ><option id="estado-civil-pessoa-parent_" value="" selected>Estado civil</option><option id="estado-civil-pessoa-parent_2" value="2">Casado(a)</option><option id="estado-civil-pessoa-parent_6" value="6">Companheiro(a)</option><option id="estado-civil-pessoa-parent_3" value="3">Divorciado(a)</option><option id="estado-civil-pessoa-parent_4" value="4">Separado(a)</option><option id="estado-civil-pessoa-parent_1" value="1">Solteiro(a)</option><option id="estado-civil-pessoa-parent_5" value="5">Vi&uacute;vo(a)</option><option id="estado-civil-pessoa-parent_7" value="7">Não informado</option></select><label for="data-nasc-pessoa-parent"> Data de nascimento </label> <input onKeyPress="formataData(this, event);" class="" placeholder="dd/mm/yyyy" type="text" name="data-nasc-pessoa-parent" id="data-nasc-pessoa-parent" value="" size="11" maxlength="10"> <div id="falecido-modal"> <label>Falecido?</label><input type="checkbox" name="falecido-parent" id="falecido-parent" style="display:inline;"> </div></fieldset><p><a id="link_cadastro_detalhado_parent">Cadastro detalhado</a></p></form></div>');
+$j('body').append('<div id="dialog-form-pessoa-parent"><form><h2></h2><table><tr><td valign="top"><fieldset><label for="cpf-pessoa-parent">CPF</label> <input type="text" name="cpf-pessoa-parent" id="cpf-pessoa-parent" size="16" maxlength="14" class="text" placeholder="000.000.000-00"> <label for="nome-pessoa-parent">Nome</label>    <input type="text " name="nome-pessoa-parent" id="nome-pessoa-parent" size="49" maxlength="255" class="text">    <label for="sexo-pessoa-parent">Sexo</label>  <select class="select ui-widget-content ui-corner-all" name="sexo-pessoa-parent" id="sexo-pessoa-parent" ><option value="" selected>Sexo</option><option value="M">Masculino</option><option value="F">Feminino</option></select>    <label for="estado-civil-pessoa-parent">Estado civil</label>   <select class="select ui-widget-content ui-corner-all" name="estado-civil-pessoa-parent" id="estado-civil-pessoa-parent"  ><option id="estado-civil-pessoa-parent_" value="" selected>Estado civil</option><option id="estado-civil-pessoa-parent_2" value="2">Casado(a)</option><option id="estado-civil-pessoa-parent_6" value="6">Companheiro(a)</option><option id="estado-civil-pessoa-parent_3" value="3">Divorciado(a)</option><option id="estado-civil-pessoa-parent_4" value="4">Separado(a)</option><option id="estado-civil-pessoa-parent_1" value="1">Solteiro(a)</option><option id="estado-civil-pessoa-parent_5" value="5">Vi&uacute;vo(a)</option><option id="estado-civil-pessoa-parent_7" value="7">Não informado</option></select><label for="data-nasc-pessoa-parent"> Data de nascimento </label> <input onKeyPress="formataData(this, event);" class="" placeholder="dd/mm/yyyy" type="text" name="data-nasc-pessoa-parent" id="data-nasc-pessoa-parent" value="" size="11" maxlength="10"> <div id="falecido-modal"> <label>Falecido?</label><input type="checkbox" name="falecido-parent" id="falecido-parent" style="display:inline;"> </div></fieldset><p><a id="link_cadastro_detalhado_parent">Cadastro detalhado</a></p></form></div>');
 
 $j('#dialog-form-pessoa-parent').find(':input').css('display', 'block');
 
@@ -122,8 +123,20 @@ var nameParent = $j("#nome-pessoa-parent"),
     sexoParent = $j("#sexo-pessoa-parent"),
     estadocivilParent = $j("#estado-civil-pessoa-parent"),
     datanascParent = $j("#data-nasc-pessoa-parent"),
+    cpfParent = $j("#cpf-pessoa-parent"),
     falecidoParent = $j("#falecido-parent"),
-    allFields = $j([]).add(nameParent).add(sexoParent).add(estadocivilParent).add(datanascParent).add(falecidoParent);
+    allFields = $j([]).add(nameParent).add(sexoParent).add(estadocivilParent).add(datanascParent).add(cpfParent).add(falecidoParent);
+
+// CPF obrigatório no modal quando o parâmetro da instituição "Exigir CPF" está ativo
+var obrigarCPFModal = $j("#obrigarCPF").val() == 1;
+
+if ($j.fn.mask) {
+    cpfParent.mask('000.000.000-00');
+}
+
+if (obrigarCPFModal) {
+    $j('label[for="cpf-pessoa-parent"]').append(' <span style="color:#cc0000">*</span>');
+}
 
 $j("#dialog-form-pessoa-parent").dialog({
     autoOpen: false,
@@ -145,6 +158,17 @@ $j("#dialog-form-pessoa-parent").dialog({
                 bValid = bValid && checkRegexp(datanascParent, /(^(((0[1-9]|[12]\d|3[01])\/(0[13578]|1[02])\/((19|[2-9]\d)\d{2}))|((0[1-9]|[12]\d|30)\/(0[13456789]|1[012])\/((19|[2-9]\d)\d{2}))|((0[1-9]|1\d|2[0-8])\/02\/((19|[2-9]\d)\d{2}))|(29\/02\/((1[6-9]|[2-9]\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00))))$)/i, "O campo data de nascimento deve ser preenchido no formato dd/mm/yyyy.");
             }
 
+            var cpfVal = cpfParent.val().trim();
+            if (obrigarCPFModal && cpfVal === '') {
+                bValid = false;
+                cpfParent.addClass("error");
+                messageUtils.error("O campo CPF é obrigatório.");
+            } else if (cpfVal !== '' && typeof validationUtils !== 'undefined' && !validationUtils.validatesCpf(cpfVal)) {
+                bValid = false;
+                cpfParent.addClass("error");
+                messageUtils.error("CPF inválido.");
+            }
+
             if (bValid) {
                 postPessoa(
                     $(this),
@@ -160,7 +184,8 @@ $j("#dialog-form-pessoa-parent").dialog({
                     null,
                     null,
                     null,
-                    falecidoParent.is(':checked')
+                    falecidoParent.is(':checked'),
+                    cpfParent.val().trim()
                 );
             }
         },
@@ -214,7 +239,8 @@ function postPessoa(
     telefone_1,
     ddd_telefone_mov,
     telefone_mov,
-    falecido
+    falecido,
+    cpf
 ) {
     var data = {
         nome: nome,
@@ -227,7 +253,8 @@ function postPessoa(
         telefone_1: telefone_1,
         ddd_telefone_mov: ddd_telefone_mov,
         telefone_mov: telefone_mov,
-        falecido: falecido
+        falecido: falecido,
+        cpf: cpf
     };
 
     var options = {

--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/PessoaFisica.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/PessoaFisica.js
@@ -245,6 +245,11 @@ $j(document).ready(function() {
   verificaCampoZonaResidencia();
   $j('#pais_residencia').on('change', verificaCampoZonaResidencia);
 
+  // CPF obrigatório quando o parâmetro da instituição "Exigir CPF" está ativo
+  if (obrigarCPF.val() == 1) {
+    $cpfField.makeRequired();
+  }
+
   // style fixup
 
   // agrupado zebra por tipo documento, branco => .formlttd, colorido => .formmdtd


### PR DESCRIPTION
## Contexto
A instituição possui o parâmetro **"Exigir CPF"** (`obrigar_cpf`). Hoje, mesmo com o parâmetro ativo, o CPF não é exigido no front-end do cadastro de pessoa, e o **cadastro simplificado** ("Cadastrar pessoa" de pai/mãe/responsável) não possui campo CPF - o que permite cadastros duplicados.

## Mudanças

### 1. Correção - CPF obrigatório no cadastro de pessoa
Quando "Exigir CPF" está ativo, o campo CPF passa a ser efetivamente obrigatório no formulário (`atendidos_cad.php`): o parâmetro é lido antes de montar o campo e o `obrigatorio` é repassado ao `campoCpf`; no `PessoaFisica.js`, o campo recebe `makeRequired()` (asterisco) quando o parâmetro está ativo. O backend já bloqueava o submit; agora o front reflete a obrigatoriedade.

### 2. Campo CPF no cadastro simplificado (pai/mãe/responsável)
Adiciona o campo CPF ao modal "Cadastrar pessoa" (`ModalCadastroPais.js`), posicionado antes do Nome, com máscara e validação. Quando "Exigir CPF" está ativo, o CPF é obrigatório (asterisco + validação). No `PessoaController` (API), valida formato, obrigatoriedade (parâmetro da instituição) e **duplicidade** (CPF já utilizado -> informa a pessoa existente), grava o CPF e expõe o valor na edição. Evita o cadastro de pessoas duplicadas no fluxo simplificado.

## Comportamento
- Parâmetro **ativo**: CPF obrigatório (com asterisco) no cadastro de pessoa e no modal simplificado; duplicidade bloqueada com a indicação da pessoa existente.
- Parâmetro **inativo**: comportamento atual preservado (CPF opcional).

## Arquivos
- `ieducar/intranet/atendidos_cad.php`
- `public/vendor/legacy/Cadastro/Assets/Javascripts/PessoaFisica.js`
- `public/vendor/legacy/Cadastro/Assets/Javascripts/ModalCadastroPais.js`
- `ieducar/modules/Api/Views/PessoaController.php`