### PR TITLE
Corrige migrations de view no upgrade de banco existente (DROP redundante sem CASCADE)

### DIFF
--- a/database/migrations/view/2026_01_01_150000_create_phones_view.php
+++ b/database/migrations/view/2026_01_01_150000_create_phones_view.php
@@ -9,8 +9,6 @@ class CreatePhonesView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('phones');
     }
 

--- a/database/migrations/view/2026_01_01_150001_create_people_view.php
+++ b/database/migrations/view/2026_01_01_150001_create_people_view.php
@@ -9,8 +9,6 @@ class CreatePeopleView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('persons');
     }
 

--- a/database/migrations/view/2026_01_01_150002_create_individuals_view.php
+++ b/database/migrations/view/2026_01_01_150002_create_individuals_view.php
@@ -9,8 +9,6 @@ class CreateIndividualsView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('individuals');
     }
 

--- a/database/migrations/view/2026_05_01_000000_create_relatorio_view_situacao_relatorios_view.php
+++ b/database/migrations/view/2026_05_01_000000_create_relatorio_view_situacao_relatorios_view.php
@@ -9,8 +9,6 @@ class CreateRelatorioViewSituacaoRelatoriosView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('relatorio.view_situacao_relatorios');
     }
 

--- a/database/migrations/view/2026_05_01_150000_create_relatorio_view_situacao_view.php
+++ b/database/migrations/view/2026_05_01_150000_create_relatorio_view_situacao_view.php
@@ -9,8 +9,6 @@ class CreateRelatorioViewSituacaoView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('relatorio.view_situacao');
     }
 

--- a/database/migrations/view/2026_06_01_000000_create_addresses_view.php
+++ b/database/migrations/view/2026_06_01_000000_create_addresses_view.php
@@ -9,8 +9,6 @@ class CreateAddressesView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('addresses');
     }
 

--- a/database/migrations/view/2026_06_01_000000_create_exporter_stages_view.php
+++ b/database/migrations/view/2026_06_01_000000_create_exporter_stages_view.php
@@ -9,8 +9,6 @@ class CreateExporterStagesView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('public.exporter_school_stages');
         $this->createView('public.exporter_school_class_stages');
         $this->createView('public.exporter_stages');

--- a/database/migrations/view/2026_06_01_000000_create_info_enrollment_view.php
+++ b/database/migrations/view/2026_06_01_000000_create_info_enrollment_view.php
@@ -9,8 +9,6 @@ class CreateInfoEnrollmentView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('public.info_enrollment');
     }
 

--- a/database/migrations/view/2026_06_01_000000_create_registrations_view.php
+++ b/database/migrations/view/2026_06_01_000000_create_registrations_view.php
@@ -9,8 +9,6 @@ class CreateRegistrationsView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('registrations');
     }
 

--- a/database/migrations/view/2026_06_01_000000_create_students_view.php
+++ b/database/migrations/view/2026_06_01_000000_create_students_view.php
@@ -9,8 +9,6 @@ class CreateStudentsView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('students');
     }
 

--- a/database/migrations/view/2026_06_01_000000_create_view_componente_curricular_view.php
+++ b/database/migrations/view/2026_06_01_000000_create_view_componente_curricular_view.php
@@ -9,8 +9,6 @@ class CreateViewComponenteCurricularView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('relatorio.view_componente_curricular');
     }
 

--- a/database/migrations/view/2026_06_01_000001_create_view_dados_escola_view.php
+++ b/database/migrations/view/2026_06_01_000001_create_view_dados_escola_view.php
@@ -9,8 +9,6 @@ class CreateViewDadosEscolaView extends Migration
 
     public function up(): void
     {
-        $this->down();
-
         $this->createView('relatorio.view_dados_escola');
     }
 


### PR DESCRIPTION
## Problema

As migrations em `database/migrations/view/` cujo `.sql` é `CREATE OR REPLACE VIEW` fazem `up() { $this->down(); $this->createView(); }`. O `down()` executa `DROP VIEW IF EXISTS <view>;` **sem `CASCADE`** (`App\Support\Database\AsView::dropView`).

- Em **instalação nova**: passa (a view não existe -> `DROP ... IF EXISTS` é no-op).
- Em **upgrade de banco existente** (2.11 → 2.12): **quebra**, porque a view já existe **com dependentes** e o `DROP` sem `CASCADE` é rejeitado.

## Erro

```
SQLSTATE[2BP01]: cannot drop view relatorio.view_situacao_relatorios because other objects depend on it
```

O `migrate` para na migration `2026_05_01_000000_create_relatorio_view_situacao_relatorios_view`, a primeira do lote com dependentes:

```
relatorio.view_situacao_relatorios
  - relatorio.view_situacao
    - public.exporter_student
    - public.exporter_student_grouped_registration
```

## Causa-raiz

O `.sql` de cada uma dessas views já é `CREATE OR REPLACE VIEW`, que **redefine a view no lugar, preservando os dependentes**. Logo, o `$this->down()` no `up()` é **redundante** e é justamente ele que quebra. Sem o `down()`, o `CREATE OR REPLACE` resolve sozinho.

## Correção

Remove a chamada `$this->down()` do `up()` nas 12 migrations cujo `.sql` é `CREATE OR REPLACE VIEW`. O método `down()` continua disponível para rollback.

As 3 migrations de `CREATE VIEW` puro (`educacenso_record20`, `exporter_person`, `exporter_phones`) **não** foram alteradas, ali o `DROP` antes do `CREATE` é necessário (CREATE VIEW puro não redefine).

## Como reproduzir

1. Banco i-Educar 2.11 já populado (views `relatorio.*` existentes com dependentes).
2. `git checkout 2.12 && composer install`
3. `php artisan migrate` -> falha em `...view_situacao_relatorios` com `2BP01`.

Com o patch, o `migrate` completa sem erro (validado num upgrade real de banco existente).

## Observação

`CREATE OR REPLACE VIEW` no Postgres só substitui mantendo as colunas existentes (pode adicionar novas no fim, mas não renomear/remover/reordenar). Nos bancos testados as assinaturas eram compatíveis. Caso uma view futura altere colunas de forma incompatível, o tratamento robusto seria `DROP ... CASCADE` + recriar a cadeia, fora do escopo deste fix.
