### PR TITLE
Valida quantidade de etapas no cadastro de curso

### DIFF
--- a/ieducar/intranet/educar_curso_cad.php
+++ b/ieducar/intranet/educar_curso_cad.php
@@ -291,7 +291,7 @@ return new class extends clsCadastro
             // Refatoração: Centraliza limpeza e flags
             $this->prepararDados();
 
-            if (! $this->validarHoraFalta()) {
+            if (! $this->validarQuantidadeEtapas() || ! $this->validarHoraFalta()) {
                 return false;
             }
 
@@ -340,7 +340,7 @@ return new class extends clsCadastro
             // Refatoração: Usa o mesmo método de preparação
             $this->prepararDados();
 
-            if (! $this->validarHoraFalta()) {
+            if (! $this->validarQuantidadeEtapas() || ! $this->validarHoraFalta()) {
                 return false;
             }
 
@@ -502,6 +502,16 @@ return new class extends clsCadastro
             $this->mensagem = "O campo 'Hora Falta (min)' não pode ser negativo.<br>";
             return false;
         }
+        return true;
+    }
+
+    private function validarQuantidadeEtapas()
+    {
+        if (! is_numeric(value: $this->qtd_etapas) || (int) $this->qtd_etapas <= 0) {
+            $this->mensagem = "O campo 'Quantidade Etapas' deve ser maior que zero.<br>";
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Closes #1096.
Closes #1019.

Resumo:
- impede salvar ou editar curso com Quantidade Etapas menor ou igual a zero
- reutiliza a validação no fluxo de cadastro e edição
- exibe mensagem clara antes da persistência

Validação:
- revisão do diff focado em ieducar/intranet/educar_curso_cad.php
- não foi possível executar php -l neste ambiente porque PHP não está instalado no Windows nem no WSL