### PR TITLE
Valida faixa etária no cadastro de série

### DIFF
--- a/ieducar/intranet/educar_serie_cad.php
+++ b/ieducar/intranet/educar_serie_cad.php
@@ -265,6 +265,10 @@ return new class extends clsCadastro
             return false;
         }
 
+        if ($this->possuiFaixaEtariaInvalida()) {
+            return false;
+        }
+
         if ($this->regras_avaliacao_id === null) {
             $this->mensagem = 'Regra de avaliação não cadastrada';
 
@@ -319,6 +323,10 @@ return new class extends clsCadastro
         if ($this->carga_horaria === null) {
             $this->mensagem = 'Carga horária inválida.';
 
+            return false;
+        }
+
+        if ($this->possuiFaixaEtariaInvalida()) {
             return false;
         }
 
@@ -391,6 +399,25 @@ return new class extends clsCadastro
         }
 
         $this->mensagem = 'Exclusão não realizada.<br>';
+
+        return false;
+    }
+
+    protected function possuiFaixaEtariaInvalida()
+    {
+        $campos = [
+            'idade_ideal' => 'Idade padrão',
+            'idade_inicial' => 'Idade inicial',
+            'idade_final' => 'Idade final',
+        ];
+
+        foreach ($campos as $campo => $label) {
+            if ($this->$campo !== null && $this->$campo !== '' && (int) $this->$campo < 0) {
+                $this->mensagem = "$label deve ser maior ou igual a zero.";
+
+                return true;
+            }
+        }
 
         return false;
     }

--- a/ieducar/intranet/educar_serie_cad.php
+++ b/ieducar/intranet/educar_serie_cad.php
@@ -265,13 +265,7 @@ return new class extends clsCadastro
             return false;
         }
 
-        if ($this->possuiFaixaEtariaInvalida()) {
-            return false;
-        }
-
-        if ($this->regras_avaliacao_id === null) {
-            $this->mensagem = 'Regra de avaliação não cadastrada';
-
+        if ($this->possuiValidacaoDeSerieInvalida()) {
             return false;
         }
 
@@ -326,13 +320,7 @@ return new class extends clsCadastro
             return false;
         }
 
-        if ($this->possuiFaixaEtariaInvalida()) {
-            return false;
-        }
-
-        if ($this->regras_avaliacao_id === null) {
-            $this->mensagem = 'Regra de avaliação não cadastrada';
-
+        if ($this->possuiValidacaoDeSerieInvalida()) {
             return false;
         }
 
@@ -405,21 +393,35 @@ return new class extends clsCadastro
 
     protected function possuiFaixaEtariaInvalida()
     {
-        $campos = [
-            'idade_ideal' => 'Idade padrão',
-            'idade_inicial' => 'Idade inicial',
-            'idade_final' => 'Idade final',
-        ];
+        return $this->possuiIdadeNegativa($this->idade_ideal, 'Idade padrão') ||
+            $this->possuiIdadeNegativa($this->idade_inicial, 'Idade inicial') ||
+            $this->possuiIdadeNegativa($this->idade_final, 'Idade final');
+    }
 
-        foreach ($campos as $campo => $label) {
-            if ($this->$campo !== null && $this->$campo !== '' && (int) $this->$campo < 0) {
-                $this->mensagem = "$label deve ser maior ou igual a zero.";
-
-                return true;
-            }
+    protected function possuiValidacaoDeSerieInvalida()
+    {
+        if ($this->possuiFaixaEtariaInvalida()) {
+            return true;
         }
 
-        return false;
+        if ($this->regras_avaliacao_id !== null) {
+            return false;
+        }
+
+        $this->mensagem = 'Regra de avaliação não cadastrada';
+
+        return true;
+    }
+
+    protected function possuiIdadeNegativa($idade, $label)
+    {
+        if ($idade === null || $idade === '' || (int) $idade >= 0) {
+            return false;
+        }
+
+        $this->mensagem = "$label deve ser maior ou igual a zero.";
+
+        return true;
     }
 
     protected function persisteRegraSerieAno()


### PR DESCRIPTION
## O que mudou
- Valida os campos de faixa etária no cadastro e edição de série.
- Impede valores negativos para idade padrão, idade inicial e idade final.

Fixes #1095

## Validação
- `git diff --check`

Não executei `php -l` localmente porque PHP não está instalado neste ambiente.