### PR TITLE
Valida nome do curso com ao menos uma letra

### DIFF
--- a/ieducar/intranet/educar_curso_cad.php
+++ b/ieducar/intranet/educar_curso_cad.php
@@ -291,7 +291,7 @@ return new class extends clsCadastro
             // Refatoração: Centraliza limpeza e flags
             $this->prepararDados();
 
-            if (! $this->validarQuantidadeEtapas() || ! $this->validarHoraFalta()) {
+            if (!$this->validarNomeCurso() || !$this->validarQuantidadeEtapas() || !$this->validarHoraFalta()) {
                 return false;
             }
 
@@ -340,7 +340,7 @@ return new class extends clsCadastro
             // Refatoração: Usa o mesmo método de preparação
             $this->prepararDados();
 
-            if (! $this->validarQuantidadeEtapas() || ! $this->validarHoraFalta()) {
+            if (!$this->validarNomeCurso() || !$this->validarQuantidadeEtapas() || !$this->validarHoraFalta()) {
                 return false;
             }
 
@@ -500,15 +500,29 @@ return new class extends clsCadastro
     {
         if ($this->hora_falta < 0) {
             $this->mensagem = "O campo 'Hora Falta (min)' não pode ser negativo.<br>";
+
             return false;
         }
+
+        return true;
+    }
+
+    private function validarNomeCurso()
+    {
+        if (preg_match(pattern: '/\p{L}/u', subject: $this->nm_curso) !== 1) {
+            $this->mensagem = "O campo 'Curso' deve conter ao menos uma letra.<br>";
+
+            return false;
+        }
+
         return true;
     }
 
     private function validarQuantidadeEtapas()
     {
-        if (! is_numeric(value: $this->qtd_etapas) || (int) $this->qtd_etapas <= 0) {
+        if (!is_numeric(value: $this->qtd_etapas) || (int) $this->qtd_etapas <= 0) {
             $this->mensagem = "O campo 'Quantidade Etapas' deve ser maior que zero.<br>";
+
             return false;
         }
 

--- a/tests/Api/LegacyCourseTest.php
+++ b/tests/Api/LegacyCourseTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Api;
+
+use App\Models\LegacyCourse;
+use Database\Factories\LegacyCourseFactory;
+use Database\Factories\LegacyEducationLevelFactory;
+use Database\Factories\LegacyEducationTypeFactory;
+use Database\Factories\LegacyRegimeTypeFactory;
+use Database\Factories\LegacyUserFactory;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class LegacyCourseTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_does_not_save_course_name_without_letters(): void
+    {
+        $user = LegacyUserFactory::new()->admin()->create();
+        $this->actingAs($user);
+
+        $course = LegacyCourseFactory::new()->make([
+            'ref_cod_instituicao' => $user->ref_cod_instituicao,
+            'ref_cod_tipo_regime' => LegacyRegimeTypeFactory::new()->create([
+                'ref_cod_instituicao' => $user->ref_cod_instituicao,
+            ])->getKey(),
+            'ref_cod_nivel_ensino' => LegacyEducationLevelFactory::new()->create([
+                'ref_cod_instituicao' => $user->ref_cod_instituicao,
+            ])->getKey(),
+            'ref_cod_tipo_ensino' => LegacyEducationTypeFactory::new()->create([
+                'ref_cod_instituicao' => $user->ref_cod_instituicao,
+            ])->getKey(),
+            'nm_curso' => '123 - @#',
+        ]);
+
+        $payload = [
+            'tipoacao' => 'Novo',
+            'ref_cod_instituicao' => $course->ref_cod_instituicao,
+            'ref_cod_tipo_regime' => $course->ref_cod_tipo_regime,
+            'ref_cod_nivel_ensino' => $course->ref_cod_nivel_ensino,
+            'ref_cod_tipo_ensino' => $course->ref_cod_tipo_ensino,
+            'nm_curso' => $course->nm_curso,
+            'sgl_curso' => $course->sgl_curso,
+            'qtd_etapas' => $course->qtd_etapas,
+            'hora_falta' => 45,
+            'carga_horaria' => $course->carga_horaria,
+            'modalidade_curso' => $course->modalidade_curso,
+        ];
+
+        $this->post('/intranet/educar_curso_cad.php', $payload)
+            ->assertOk()
+            ->assertSee("O campo 'Curso' deve conter ao menos uma letra.", false);
+
+        $this->assertDatabaseMissing((new LegacyCourse)->getTable(), [
+            'nm_curso' => $course->nm_curso,
+        ]);
+    }
+}


### PR DESCRIPTION
## O que foi alterado

- valida que o nome do curso contenha ao menos uma letra
- aplica a regra tanto no cadastro quanto na edição
- adiciona teste de regressão para nomes formados somente por números e símbolos

A validação permite nomes legítimos que combinam letras, números e símbolos, como `EJA - Fase 1`.

## Validação

- `vendor/bin/pest tests/Api/LegacyCourseTest.php`
- `vendor/bin/pint --test ieducar/intranet/educar_curso_cad.php tests/Api/LegacyCourseTest.php`
- verificação de sintaxe PHP nos dois arquivos alterados

Closes #1017