### PR TITLE
Validador de Cadastro do Aluno: CPF ou INEP

### DIFF
--- a/ieducar/modules/Api/Views/AlunoController.php
+++ b/ieducar/modules/Api/Views/AlunoController.php
@@ -205,7 +205,9 @@ class AlunoController extends ApiCoreController
             $this->validatesResponsavel() &&
             $this->validatesTransporte() &&
             $this->validatesUniquenessOfAlunoInepId() &&
-            $this->validatesUniquenessOfAlunoEstadoId();
+            $this->validatesUniquenessOfAlunoEstadoId() &&
+            $this->validateCpfUniqueness() &&
+            $this->validateCpfOrInep();
     }
 
     protected function canPost()
@@ -227,6 +229,8 @@ class AlunoController extends ApiCoreController
             $this->validateInepExam() &&
             $this->validateTechnologicalResources() &&
             $this->validateCpfCode() &&
+            $this->validateCpfUniqueness() &&
+            $this->validateCpfOrInep() &&
             $this->validateBirthCertificate() &&
             $this->validateInepCode();
     }
@@ -237,6 +241,11 @@ class AlunoController extends ApiCoreController
         $user = Auth::user();
 
         $cpf = $this->getRequest()->id_federal;
+        $naoPossuiCpf = $this->getRequest()->nao_possui_cpf == 'on';
+
+        if ($naoPossuiCpf) {
+            return true;
+        }
 
         if ($user->ref_cod_instituicao) {
             $strictValitation = LegacyInstitution::query()
@@ -253,6 +262,45 @@ class AlunoController extends ApiCoreController
                 return true;
             }
             $this->messenger->append('O CPF informado é inválido');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function validateCpfUniqueness()
+    {
+        $cpf = $this->getRequest()->id_federal;
+        $pessoaId = $this->getRequest()->pessoa_id;
+
+        if (empty($cpf)) {
+            return true;
+        }
+
+        $cpfInt = idFederal2int($cpf);
+
+        $existing = \DB::table('cadastro.fisica')
+            ->where('cpf', $cpfInt)
+            ->where('idpes', '!=', $pessoaId)
+            ->first();
+
+        if ($existing) {
+            $this->messenger->append("O CPF informado já está cadastrado para outra pessoa (ID: {$existing->idpes}).");
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function validateCpfOrInep()
+    {
+        $naoPossuiCpf = $this->getRequest()->nao_possui_cpf == 'on';
+        $inep = $this->getRequest()->aluno_inep_id;
+
+        if ($naoPossuiCpf && empty($inep)) {
+            $this->messenger->append('Informe o Código INEP do aluno, pois o CPF não foi informado.');
 
             return false;
         }

--- a/ieducar/modules/Cadastro/Views/AlunoController.php
+++ b/ieducar/modules/Cadastro/Views/AlunoController.php
@@ -462,6 +462,13 @@ class AlunoController extends Portabilis_Controller_Page_EditController
         $this->campoOculto('renda_mensal', (int) $this->renda_mensal);
         $this->campoCpf('id_federal', 'CPF', $valorCpf);
 
+        $naoPossuiCpf = $this->getRequest()->nao_possui_cpf == 'on';
+        $options = [
+            'label' => 'Não possui CPF',
+            'value' => $naoPossuiCpf ? 'checked' : '',
+        ];
+        $this->inputsHelper()->checkbox('nao_possui_cpf', $options);
+
         $options = [
             'required' => false,
             'label' => 'NIS (PIS/PASEP)',

--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/Aluno.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/Aluno.js
@@ -22,6 +22,17 @@ $j("#autorizado_dois").change(abriCampoTres);
 $j("#autorizado_tres").change(abriCampoQuatro);
 $j("#autorizado_quatro").change(abriCampoCinco);
 
+$naoPossuiCpf.change(function () {
+  if ($j(this).is(":checked")) {
+    $cpfField.val("").makeUnrequired();
+    aluno_inep_id.makeRequired();
+    $j("#tr_aluno_inep_id").show();
+  } else {
+    $cpfField.makeRequired();
+    aluno_inep_id.makeUnrequired();
+  }
+});
+
 function abriCampoDois() {
   $j("#autorizado_dois").closest("tr").show();
   $j("#parentesco_dois").closest("tr").show();
@@ -54,6 +65,7 @@ var $idField = $j("#id");
 var $nomeField = $j("#pessoa_nome");
 var $cpfField = $j("#id_federal");
 var obrigarCPF = $j("#obrigarCPF");
+var $naoPossuiCpf = $j("#nao_possui_cpf");
 
 var $resourceNotice = $j("<span>")
   .html("")
@@ -242,7 +254,14 @@ function handleShowSubmit() {
 };
 
 function formularioValido() {
-  if ( obrigarCPF.val() == 1 && $j("#tipo_nacionalidade").val() != 3  && !$cpfField.val()) {
+  var semCpf = $naoPossuiCpf.is(":checked");
+
+  if (semCpf) {
+    var codigoInep = $j("#aluno_inep_id").val();
+    if (!codigoInep || codigoInep.length != 12) {
+      return codigoInepInvalido();
+    }
+  } else if (obrigarCPF.val() == 1 && $j("#tipo_nacionalidade").val() != 3 && !$cpfField.val()) {
     messageUtils.error(
       "É necessário o preenchimento do CPF"
     );


### PR DESCRIPTION
Implementa o validador de cadastro de aluno conforme issue #1182.

### Alterações:

1. **Formulário de aluno** (AlunoController.php - modules/Cadastro/Views):
   - Adicionado checkbox "Não possui CPF" ao lado do campo CPF

2. **JavaScript** (Aluno.js):
   - Ao marcar "Não possui CPF", o CPF é limpo e removido como obrigatório, e o campo INEP passa a ser obrigatório
   - Ao desmarcar, o comportamento original é restaurado
   - Validação no submit: se "Não possui CPF" estiver marcado, INEP deve ter 12 dígitos

3. **API** (AlunoController.php - modules/Api/Views):
   - `validateCpfCode()`: Ignora validação de CPF se "Não possui CPF" estiver marcado
   - `validateCpfUniqueness()`: Nova validação que verifica se CPF já está cadastrado para outra pessoa
   - `validateCpfOrInep()`: Nova validação que garante INEP informado quando CPF não for preenchido
