### PR TITLE
Otimiza busca de escolas existentes em createAcademicYearForMultipleSchools

### DIFF
--- a/app/Services/AcademicYearService.php
+++ b/app/Services/AcademicYearService.php
@@ -273,8 +273,11 @@ class AcademicYearService
 
         $existingActiveSchools = $this->getExistingAcademicYearSchools($schoolIds, $year);
 
+        $lookup = array_flip($existingActiveSchools);
+
         foreach ($schoolIds as $schoolId) {
-            if (in_array($schoolId, $existingActiveSchools)) {
+            if (isset($lookup[$schoolId])) {
+
                 $skippedSchools[] = $schoolId;
 
                 continue;


### PR DESCRIPTION
## Descrição

Substitui `in_array` por `array_flip` + `isset` em `createAcademicYearForMultipleSchools`
(`AcademicYearService`), eliminando uma busca linear repetida dentro de loop e reduzindo
a complexidade de **O(n·m) para O(n + m)**.

---

## Contexto do Problema

O método percorre `$schoolIds` (tamanho **n**) e, a cada iteração, chama
`in_array($schoolId, $existingActiveSchools, true)`.  
`in_array` realiza uma varredura linear em `$existingActiveSchools` (tamanho **m**),
resultando em **O(n·m)** comparações no total.

Em cenários maiores do i-Educar, `n` e `m` crescem ainda mais, tomando, no pior caso, o comportamento **O(n²)**.

```php
foreach ($schoolIds as $schoolId) {
    if (in_array($schoolId, $existingActiveSchools, true)) {
        continue; 
    }
    // ... cria ano letivo
}
```

---

## Solução

`array_flip` constrói um mapa invertido `valor => índice` em **O(m)**, uma única vez.
A partir daí, cada verificação de existência usa `isset`, que opera em média **O(1)**
via hash table interna do PHP.

```php
$lookup = array_flip($existingActiveSchools);

foreach ($schoolIds as $schoolId) {
    if (isset($lookup[$schoolId])) {
        continue;
    }
    // ... cria ano letivo
}
```

| | Antes | Depois |
|---|---|---|
| Pré-processamento | — | O(m) — `array_flip` uma vez |
| Verificação por escola | O(m) — `in_array` | O(1) — `isset` |
| **Total** | **O(n · m)** | **O(n + m)** |

---

## Validação de Correção

Para garantir equivalência, foram gerados datasets com
tamanhos de 10 a 50.000 escolas e três proporções de escolas já existentes
(**10%, 50% e 100%** do total), com distribuições de IDs **aleatória, ordenada e
reversa**.

---

## Benchmark de Desempenho

**Configuração:** PHPBench · 30 iterações · 30 execuções de warm-up · 3 distribuições de entrada (random, sorted, reversed) · 3 proporções de existentes (10%, 50%, 100%)

### Tempos médios por tamanho de entrada (proporção 50%, entrada aleatória)

| n (escolas) | Original (`in_array`) | Otimizado (`array_flip + isset`) | Speedup |
|---:|---:|---:|---:|
| 10 | 0,54 µs | 0,54 µs | ~1× |
| 100 | 7,17 µs | 3,16 µs | **~2,3×** |
| 1.000 | 352,56 µs | 27,93 µs | **~12,6×** |
| 5.000 | 8.128,17 µs | 151,71 µs | **~53,6×** |
| 10.000 | 32.117,85 µs | 287,85 µs | **~111,6×** |
| 50.000 | 795.459,94 µs | 1.610,77 µs | **~494×** |

> Para entradas pequenas (n ≤ 10) o `array_flip` neutraliza o ganho.

### Speedup por distribuição de entrada (n=50.000, proporção 50%)

| Distribuição | Original | Otimizado | Speedup |
|---|---:|---:|---:|
| Aleatória (random) | 795.459 µs | 1.611 µs | **~494×** |
| Reversa (reversed) | 796.442 µs | 1.167 µs | **~682×** |
| Ordenada (sorted) | 797.957 µs | 1.081 µs | **~738×** |

O speedup é ligeiramente maior em entradas ordenadas e reversas porque o `in_array` original percorre o array até encontrar o elemento, logo as entradas ordenadas desfavoravelmente aumentam o caminho médio percorrido.

### Gráficos

**Tempo de execução — escala logarítmica (proporção 50%)**  

<img width="3246" height="3642" alt="time_by_workload" src="https://github.com/user-attachments/assets/9e833f60-0145-4a56-9a48-fbd63c3717c3" />

**Speedup (proporção 50%)**  

<img width="3249" height="3642" alt="speedup" src="https://github.com/user-attachments/assets/9377f0c3-40c8-4b18-a48c-54f45c380550" />

> Os gráficos acima referem-se à proporção de 50% de escolas existentes. Resultados completos para 10% e 100% estão na planilha de dados abaixo.

---

## Dados Completos

Planilha com todos os tamanhos de entrada testados, tempo médio, desvio padrão, memória
e implementação utilizada:

[Google Sheets — Planilhas](https://docs.google.com/spreadsheets/d/1aJ0bHQbEFoU94VYpafwcrKabiOyjmr4we7Ka1tTPsnQ/edit)