### PR TITLE
fix(aluno): reject invalid CPF before querying student search

### DIFF
--- a/ieducar/intranet/educar_aluno_lst.php
+++ b/ieducar/intranet/educar_aluno_lst.php
@@ -3,6 +3,7 @@
 use App\Models\DataSearch\StudentFilter;
 use App\Models\LegacyGeneralConfiguration;
 use App\Models\LegacyStudent;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 return new class extends clsListagem
 {
@@ -125,10 +126,13 @@ return new class extends clsListagem
         $this->nome_pai = $this->cleanNameSearch(name: $this->nome_pai);
         $this->nome_mae = $this->cleanNameSearch(name: $this->nome_mae);
 
+        $cpf = preg_replace(pattern: '/\D/', replacement: '', subject: $this->cpf_aluno);
+        $cpfInvalido = $cpf && !Portabilis_Utils_Validation::validatesCpf(cpf: $cpf);
+
         $dataFilter = [
             'rg' => preg_replace(pattern: '/\D/', replacement: '', subject: $this->rg_aluno),
             'year' => $this->ano,
-            'cpf' => preg_replace(pattern: '/\D/', replacement: '', subject: $this->cpf_aluno),
+            'cpf' => $cpf,
             'inep' => $this->cod_inep,
             'grade' => $this->ref_cod_serie,
             'school' => $this->ref_cod_escola,
@@ -148,8 +152,17 @@ return new class extends clsListagem
         $this->limite = 20;
         $this->offset = ($_GET["pagina_{$this->nome}"]) ? $_GET["pagina_{$this->nome}"] * $this->limite - $this->limite : 0;
 
-        $studentFilter = new StudentFilter(...$dataFilter);
-        $students = LegacyStudent::query()->findStudentWithMultipleSearch(studentFilter: $studentFilter);
+        if ($cpfInvalido) {
+            // Um CPF inválido nunca deve corresponder a alunos reais. Sem esse
+            // corte, o valor era usado como está na busca (where('cpf', $cpf)),
+            // e um CPF inválido usado como placeholder para "sem CPF cadastrado"
+            // (ex.: 00000000000) pode estar salvo em vários registros, fazendo
+            // a busca por um CPF inválido retornar múltiplos alunos.
+            $students = new LengthAwarePaginator(items: [], total: 0, perPage: $this->limite, options: ['pageName' => 'pagina_' . $this->nome]);
+        } else {
+            $studentFilter = new StudentFilter(...$dataFilter);
+            $students = LegacyStudent::query()->findStudentWithMultipleSearch(studentFilter: $studentFilter);
+        }
 
         foreach ($students as $student) {
             $nomeAluno = $student->person->name;

--- a/ieducar/intranet/educar_aluno_lst.php
+++ b/ieducar/intranet/educar_aluno_lst.php
@@ -127,7 +127,6 @@ return new class extends clsListagem
         $this->nome_mae = $this->cleanNameSearch(name: $this->nome_mae);
 
         $cpf = preg_replace(pattern: '/\D/', replacement: '', subject: $this->cpf_aluno);
-        $cpfInvalido = $cpf && !Portabilis_Utils_Validation::validatesCpf(cpf: $cpf);
 
         $dataFilter = [
             'rg' => preg_replace(pattern: '/\D/', replacement: '', subject: $this->rg_aluno),
@@ -152,40 +151,10 @@ return new class extends clsListagem
         $this->limite = 20;
         $this->offset = ($_GET["pagina_{$this->nome}"]) ? $_GET["pagina_{$this->nome}"] * $this->limite - $this->limite : 0;
 
-        if ($cpfInvalido) {
-            // Um CPF inválido nunca deve corresponder a alunos reais. Sem esse
-            // corte, o valor era usado como está na busca (where('cpf', $cpf)),
-            // e um CPF inválido usado como placeholder para "sem CPF cadastrado"
-            // (ex.: 00000000000) pode estar salvo em vários registros, fazendo
-            // a busca por um CPF inválido retornar múltiplos alunos.
-            $students = new LengthAwarePaginator(items: [], total: 0, perPage: $this->limite, options: ['pageName' => 'pagina_' . $this->nome]);
-        } else {
-            $studentFilter = new StudentFilter(...$dataFilter);
-            $students = LegacyStudent::query()->findStudentWithMultipleSearch(studentFilter: $studentFilter);
-        }
+        $students = $this->searchStudents(cpf: $cpf, dataFilter: $dataFilter);
 
         foreach ($students as $student) {
-            $nomeAluno = $student->person->name;
-            $nomeSocial = $student->individual->nome_social;
-
-            if ($nomeSocial) {
-                $nomeAluno = $nomeSocial . '<br> <i>Nome de registro: </i>' . $nomeAluno;
-            }
-
-            $nomeResponsavel = mb_strtoupper(string: $student->getGuardianName() ?? '-');
-            $cpfResponsavel = ucfirst(string: $student->getGuardianCpf());
-            $nomeMae = mb_strtoupper(string: $student->individual->mother->name ?? '-');
-
-            $linhas = array_filter(array: [
-                "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$student->cod_aluno</a>",
-                $configuracoes['mostrar_codigo_inep_aluno'] === 1 ? "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">" . ($student->inepNumber ?? '-'). '</a>' : null,
-                "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$nomeAluno</a>",
-                "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$nomeMae</a>",
-                "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$nomeResponsavel</a>",
-                "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$cpfResponsavel</a>",
-            ]);
-
-            $this->addLinhas(linha: $linhas);
+            $this->addLinhas(linha: $this->studentRow(student: $student, configuracoes: $configuracoes));
         }
 
         $this->addPaginador2(strUrl: 'educar_aluno_lst.php', intTotalRegistros: $students->total(), mixVariaveisMantidas: $_GET, nome: $this->nome, intResultadosPorPagina: $this->limite);
@@ -212,5 +181,44 @@ return new class extends clsListagem
     public function cleanNameSearch($name)
     {
         return trim(string: preg_replace(pattern: '/\W/', replacement: ' ', subject: limpa_acentos(str_nome: $name)));
+    }
+
+    private function searchStudents(?string $cpf, array $dataFilter)
+    {
+        if ($cpf && !Portabilis_Utils_Validation::validatesCpf(cpf: $cpf)) {
+            // Um CPF inválido nunca deve corresponder a alunos reais. Sem esse
+            // corte, o valor era usado como está na busca (where('cpf', $cpf)),
+            // e um CPF inválido usado como placeholder para "sem CPF cadastrado"
+            // (ex.: 00000000000) pode estar salvo em vários registros, fazendo
+            // a busca por um CPF inválido retornar múltiplos alunos.
+            return new LengthAwarePaginator(items: [], total: 0, perPage: $this->limite, options: ['pageName' => 'pagina_' . $this->nome]);
+        }
+
+        $studentFilter = new StudentFilter(...$dataFilter);
+
+        return LegacyStudent::query()->findStudentWithMultipleSearch(studentFilter: $studentFilter);
+    }
+
+    private function studentRow(LegacyStudent $student, $configuracoes): array
+    {
+        $nomeAluno = $student->person->name;
+        $nomeSocial = $student->individual->nome_social;
+
+        if ($nomeSocial) {
+            $nomeAluno = $nomeSocial . '<br> <i>Nome de registro: </i>' . $nomeAluno;
+        }
+
+        $nomeResponsavel = mb_strtoupper(string: $student->getGuardianName() ?? '-');
+        $cpfResponsavel = ucfirst(string: $student->getGuardianCpf());
+        $nomeMae = mb_strtoupper(string: $student->individual->mother->name ?? '-');
+
+        return array_filter(array: [
+            "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$student->cod_aluno</a>",
+            $configuracoes['mostrar_codigo_inep_aluno'] === 1 ? "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">" . ($student->inepNumber ?? '-'). '</a>' : null,
+            "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$nomeAluno</a>",
+            "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$nomeMae</a>",
+            "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$nomeResponsavel</a>",
+            "<a href=\"educar_aluno_det.php?cod_aluno=$student->cod_aluno\">$cpfResponsavel</a>",
+        ]);
     }
 };


### PR DESCRIPTION
## Summary

Fixes #1058.

`ieducar/intranet/educar_aluno_lst.php` (the student search form) strips the CPF field down to digits with `preg_replace('/\D/', '', ...)` and passes that value straight into `LegacyStudentBuilder::whereCpf()`, which does an exact `where('cpf', $cpf)` match. The checksum is never validated.

`cadastro.fisica.cpf` has no unique constraint. A student without a real CPF on file is commonly stored with a placeholder value such as `00000000000`. Since that placeholder is itself an invalid CPF, typing in an invalid/mistyped CPF can coincidentally match that placeholder and return every student who shares it — matching the reported behavior of an invalid CPF returning multiple students instead of zero.

`Portabilis_Utils_Validation::validatesCpf()` already implements the CPF checksum validation and is used for this exact purpose elsewhere in the codebase during registration (`PessoaController::validateCpf()`, `atendidos_cad.php`), but it was never applied to this search filter.

## Fix

Validate the CPF with `Portabilis_Utils_Validation::validatesCpf()` before it reaches the query. When a non-empty CPF fails validation, the search short-circuits to an empty result set (via an empty `LengthAwarePaginator`) instead of running the query, so an invalid CPF can never match student records — regardless of what happens to be stored as a placeholder value.

## Notes

- I don't believe this affects any legitimate partial/prefix CPF search: `whereCpf()` already does an exact match (`where('cpf', $cpf)`), not a `LIKE`, so partial digit entry never matched multiple students in the first place — it simply matched nothing (or, in the buggy case, happened to match a shared invalid placeholder).
- For comparison, `pesquisa_pessoa_lst.php` (a sibling person-search screen) already validates the CPF checksum before querying and shows an explicit "Informado um CPF Inválido" message otherwise, so gating the query on CPF validity is an established pattern in this codebase, not a new behavior being introduced here.
- I was not able to set up a full local instance (DB seeding + app) to reproduce this end-to-end, but I did verify the actual validators in this repo (`validaCPF()` and `Portabilis_Utils_Validation::validatesCpf()`) reject the placeholder value `00000000000` (and other repeated-digit placeholders), consistent with the root cause above.